### PR TITLE
Commande publique - nouvelles données

### DIFF
--- a/pages/donnees-fiscalite-commande-publique.md
+++ b/pages/donnees-fiscalite-commande-publique.md
@@ -17,6 +17,7 @@ datasets:
 - les-finances-publiques-locales-2020-fascicule-1
 - les-finances-publiques-locales-2019
 - amendements-deposes-a-lassemblee-nationale-lies-aux-plf-et-plfss-2018-2019-2020
+- donnees-de-comptabilite-generale-de-letat
 - projet-de-loi-de-finances-pour-2020-plf-2020-donnees-du-plf-et-des-annexes-projet-annuel-de-performance-pap
 - projet-de-loi-de-finances-pour-2020-plf-2020-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations
 - projets-de-loi-de-finances-redaction-de-1ere-lecture-au-senat-resultant-des-travaux-de-lassemblee-nationale
@@ -74,6 +75,7 @@ datasets:
 
 ### Par [le Ministère de l'Economie et des Finances](https://www.data.gouv.fr/fr/organizations/ministere-de-leconomie-et-des-finances/)
 
+- [Données de comptabilité générale de l'État](https://www.data.gouv.fr/fr/datasets/donnees-de-comptabilite-generale-de-letat/)
 - [Projet de loi de finances pour 2020 (PLF 2020), données du PLF et des annexes projet annuel de performance (PAP)](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-du-plf-et-des-annexes-projet-annuel-de-performance-pap/)
 - [Projet de loi de finances pour 2020 (PLF 2020), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
 

--- a/pages/donnees-fiscalite-commande-publique.md
+++ b/pages/donnees-fiscalite-commande-publique.md
@@ -37,6 +37,15 @@ datasets:
 - comptes-individuels-des-departements-et-des-collectivites-territoriales-uniques-fichier-global-a-compter-de-2008
 - comptes-individuels-des-regions-fichier-global-a-compter-de-2008
 - comptes-individuels-des-collectivites
+- comptes-consolides-des-regions-2012-2019
+- comptes-des-sdis-2012-2019
+- comptes-consolides-des-departements-2012-2019
+- comptes-des-communes-2012-2019
+- comptes-des-departements-2012-2019
+- comptes-des-regions-2012-2019
+- comptes-des-groupements-a-fiscalite-propre-2012-2019
+- comptes-consolides-des-communes-2012-2019
+- comptes-consolides-des-groupements-a-fiscalite-propre-2012-2019
 ---
 
 ## Données de [la cour des comptes](https://www.data.gouv.fr/fr/organizations/cour-des-comptes/)
@@ -44,6 +53,18 @@ datasets:
 - [Rapports d'observations définitives des Chambres Régionales des Comptes (CRC) et réponses associées ROD_et_reponses](https://www.data.gouv.fr/fr/datasets/rapports-dobservations-definitives-des-chambres-regionales-des-comptes-crc-et-reponses-associees-1/#_)
 - [Les finances publiques locales 2020 – Fascicule 1](https://www.data.gouv.fr/fr/datasets/les-finances-publiques-locales-2020-fascicule-1/)
 - [Les finances publiques locales 2019](https://www.data.gouv.fr/fr/datasets/les-finances-publiques-locales-2019/)
+
+## Données de l'[Observatoire des Finances et de la Gestion publique Locales](https://www.data.gouv.fr/fr/organizations/observatoire-des-finances-et-de-la-gestion-publique-locales/)
+
+- [Comptes des régions 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-regions-2012-2019/)
+- [Comptes consolidés des groupements à fiscalité propre 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-groupements-a-fiscalite-propre-2012-2019/)
+- [Comptes consolidés des communes 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-communes-2012-2019/)
+- [Comptes des départements 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-departements-2012-2019/)
+- [Comptes des communes 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-communes-2012-2019/)
+- [Comptes des SDIS 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-sdis-2012-2019/)
+- [Comptes consolidés des régions 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-regions-2012-2019/)
+- [Comptes consolidés des départements 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-departements-2012-2019/)
+- [Comptes des groupements à fiscalité propre 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-groupements-a-fiscalite-propre-2012-2019/)
 
 ## Données relatives au projet de loi Finance (PLF)
 


### PR DESCRIPTION
Suite à [la pull request de Mathilde](https://github.com/etalab/datagouvfr-pages/pull/4), j'ai ajouté les données de l'Observatoire des Finances et de la Gestion publique Locales, ainsi que les données de comptabilité générale de l'État (Ministère de l'Économie), comme [suggéré par Paul Antoine](https://github.com/etalab/datagouvfr-pages/pull/4#issuecomment-683762403).
