### PR TITLE
Publication page comptes publics

### DIFF
--- a/pages/donnees-cles-par-sujet.md
+++ b/pages/donnees-cles-par-sujet.md
@@ -18,3 +18,4 @@ Retrouvez ici une sélection de jeux de données clés regroupés par sujet :
 - [Les données relatives au COVID-19](https://www.data.gouv.fr/fr/pages/donnees-coronavirus)
 - [Les données des élections](https://www.data.gouv.fr/fr/pages/donnees-des-elections)
 - [Les données relatives aux associations et aux fondations](https://www.data.gouv.fr/fr/pages/donnees-associations-fondations)
+- [Les données relatives aux comptes publics de l'État](https://www.data.gouv.fr/fr/pages/donnees-comptes-publics)


### PR DESCRIPTION
J'ai ajouté le lien à [la page sur les données relatives aux comptes publics de l'État](https://www.data.gouv.fr/fr/pages/donnees-comptes-publics) à la [page index](https://www.data.gouv.fr/fr/pages/donnees-cles-par-sujet).