### PR TITLE
Migration of existing static pages to markdown

### DIFF
--- a/cgu.md
+++ b/cgu.md
@@ -1,0 +1,245 @@
+---
+title: Conditions générales d'utilisations
+keywords:
+  - cgu
+  - terms
+description: Conditions générales d'utilisations
+menu:
+  - footer
+---
+
+# Conditions d’utilisation
+
+[Data.gouv.fr][] est la plateforme ouverte des données publiques du Gouvernement français.
+
+Elle est éditée et développée par la mission Etalab (ci-après, Etalab) de la Direction interministérielle du numérique et du système d’information et de communication de l’Etat (DINSIC).
+
+Toute utilisation de la plateforme [data.gouv.fr][] (ci-après, la Plateforme) est subordonnée au respect des présentes conditions générales d’utilisation (CGU).
+
+Est défini comme :
+
+**API (web)** : interface web structurée permettant d’interagir automatiquement avec un système d’information, qui inclut généralement la récupération de données à la demande ;
+
+**Autorités administratives** : toute personne publique ou privée chargée d’une mission de service public (article L. 300-2 du code des relations du public et de l’administration (CRPA)) ;
+
+**Contributeur** : toute personne inscrite sur la plateforme, notamment, afin de mettre à disposition un Jeu de données dont la publication présente un intérêt public, telles que celles qui :
+
+- assurent une meilleure information des citoyens, notamment en matière économique, sociale, sanitaire ou environnementale ;
+- permettent une conduite plus efficace de politiques publiques ;
+- bénéficient au développement économique ;
+- concourent à la recherche scientifique et à l’investigation journalistique.
+
+ou dans le but de discuter ou de diffuser une réutilisation ;
+
+**Informations publiques** : informations figurant dans des documents produits ou reçus par des autorités administratives, communicables à toute personne ou ayant fait l’objet d’une diffusion publique conforme aux articles [L. 312-1 à L. 312-1-2](https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367739&dateTexte=&categorieLien=cid) du CRPA et sur lesquelles des tiers ne détiennent pas de droit de propriété intellectuelle (articles L. 321-1 et suivants) ;
+
+**Jeu de données** : ensemble cohérent de ressources ou d’informations (fichiers de données, fichiers d’explications, API, lien…) et de métadonnées (présentation, date de publication, mots-clefs, couverture géographique/temporelle…), sur un thème donné.
+
+**Réutilisation** : utilisation par toute personne (Réutilisateur) des données publiées à des fins autres que celles pour lesquelles elles ont été produites ou reçues ;
+
+**Utilisateur** : toute personne accédant à la Plateforme afin de consulter ou télécharger des contenus ou d’y contribuer.
+
+## Objet
+
+La Plateforme permet :
+
+- la publication par les Autorités administratives d’Informations publiques et par tout Contributeur de données dont la publication présente un intérêt public,
+- la consultation ou le téléchargement de ces données par tout Utilisateur,
+- une discussion autour des données, ainsi que la diffusion de Jeux de données enrichis ou de Réutilisations.
+
+## Fonctionnalités
+
+L’utilisation de la Plateforme est libre et gratuite.
+
+### Consultation et téléchargement des données
+
+La consultation des contenus mis à disposition ou leur téléchargement ne nécessite aucune d’inscription préalable.
+
+### Inscription sur la plateforme et fonctionnalités liées
+
+Toute personne, morale ou physique, publique ou privée, peut contribuer à la Plateforme, en publiant des Jeux de données, des Réutilisations de ceux-ci, en publiant des textes, ressources et commentaires relatifs aux Jeux de données.
+
+Pour ce faire, l’Utilisateur s’inscrit sur la Plateforme. Cette inscription est propre à sa personne et non à l’entité ou personne morale qu’il représente.
+
+En s’inscrivant, l’Utilisateur crée un profil sur la Plateforme. Pour plus de précisions, voir la rubrique Vie privée.
+
+Dès validation de son inscription, les différentes fonctionnalités sont disponibles.
+
+Le Contributeur dispose de fonctionnalités « communautaires », notamment :
+
+- créer ou rejoindre une organisation (voir rubrique dédiée),
+- publier un Jeu de données sous la forme d’un fichier téléchargeable, d’un lien ou d’une API ;
+- publier des ressources additionnelles associées à un Jeu de données proposé par un autre Contributeur, par exemple, le même Jeu de données enrichi,
+- publier une Réutilisation, c’est-à-dire un lien vers celle-ci ainsi qu’une présentation ;
+- publier un commentaire dans une discussion sur un Jeu de données, par exemple, pour signaler des anomalies dans une ressource ou un Jeu de données.
+
+Il dispose également d’autres fonctionnalités telles que le suivi d’un Jeu de données ou d’une organisation ; le partage et l’intégration d’un Jeu de données ou d’une ressource directement sur un autre site.
+
+Enfin, il peut participer au contrôle de la qualité de la Plateforme en signalant les contenus n’ayant pas vocation à y figurer (illicites ou contraires aux CGU). Il peut également contacter directement le Contributeur ayant publié un Jeu de données.
+
+### Organisations et fonctionnalités liées
+
+Les Contributeurs peuvent créer ou rejoindre des organisations. Il s’agit le plus souvent de personnes morales (autorités administratives, associations, entreprises) mais également de groupes informels. Chaque organisation a un espace dédié animé par un ou plusieurs administrateurs.
+
+Les organisations peuvent :
+
+- publier des Jeux de données ;
+- publier des ressources additionnelles ;
+- publier des Réutilisations.
+
+Elles ne peuvent pas commenter dans une discussion. Seuls les Contributeurs personnes physiques peuvent le faire.
+
+Etalab propose deux types de certifications des organisations :
+
+- la certification de service public : elle identifie les Autorités administratives ;
+- la certification d’authenticité de l’organisation.
+
+Pour être certifiée, l’organisation en fait la demande par courriel à : [certification@data.gouv.fr](mailto:certification@data.gouv.fr).
+
+Cette certification permet notamment de bénéficier d’un meilleur classement dans les résultats du moteur de recherche de la plateforme. La certification d’une organisation n’emporte pas la certification des Jeux de données qu’elle met à disposition.
+
+Etalab se réserve la possibilité de révoquer une certification pour tout manquement aux présentes conditions d’utilisation.
+
+## Code de conduite et responsabilités des Contributeurs
+
+### Publication d’un Jeu de données ou d’une Réutilisation
+
+#### Règles générales
+
+La Plateforme diffuse des Informations publiques et les données d’intérêt public publiées par les Contributeurs qui peuvent être mises à disposition en téléchargement, par le biais d’une API ou référencées par un lien.
+
+La Plateforme n’a pas vocation à diffuser des données publicitaires, de promotion d’intérêts privés, contrevenant à l’ordre public ou, plus généralement, illicite. Etalab est susceptible, le cas échéant, sans préavis, de supprimer ou rendre impossible l’accès à de telles données.
+
+Etalab encourage les Contributeurs à fiabiliser et documenter les données qu’ils publient. Les Autorités administratives actualisent les bases de données qu’elles publient, conformément à l’article L. 312-1-1 du CRPA.
+
+Les Contributeurs publiant un Jeu de donnée sont invités à animer la page dédiée ; à cette fin, ils sont notifiés par courriel de chaque nouvelle contribution sur cette page (discussion, commentaire, signalement, suivi, ajout d’une ressource communautaire ou d’une Réutilisation).
+
+Les Contributeurs sont seuls responsables des données, métadonnées ou contenus qu’ils publient sur la Plateforme.
+
+#### Données à caractère personnel
+
+Les Jeux de données contenant des données à caractère personnel, c’est-à-dire des données, y compris non nominatives, permettant la ré-identification de personnes physiques, ne peuvent pas être diffusés par la Plateforme sauf si les personnes concernées ont donné leur accord ou si une disposition législative ou le [décret n° 2018-1117 du 10 décembre 2018](https://www.legifrance.gouv.fr/affichTexte.do;jsessionid=6601358DD354B115F0081BF3A210EB8D.tplgfr42s_1?cidTexte=JORFTEXT000037797147&dateTexte=&oldAction=rechJO&categorieLien=id&idJO=JORFCONT000037796937) à l’article L. 312-1-2 du CRPA le permet.
+
+Le Contributeur publiant le Jeu de données est responsable des jeux de données qu’il publie sur la Plateforme et s’assure que cette publication est conforme à la législation en vigueur. Il prend toute mesure nécessaire à cette fin et Etalab l’encourage à mentionner la présence de données à caractère personnel dans la documentation accompagnant le Jeu de données et préciser, lorsqu’elles existent, les restrictions juridiques à la Réutilisation.
+
+Le Réutilisateur de telles données doit se conformer à la législation relative à la protection des données à caractère personnel en vigueur dans son territoire de résidence et respecter les stipulations pertinentes de la licence attachée à ces données.
+
+#### Données couvertes par des droits de propriété intellectuelle
+
+Lorsque l’Autorité administrative ou le Contributeur publie un jeu de données comprenant des droits de propriété intellectuelle qui font obstacle à la Réutilisation, il mentionne leur présence dans la documentation accompagnant le Jeu de données. Il indique l’identité de la personne physique ou morale titulaire de ces droits ou, si celle-ci n’est pas connue, l’identité de la personne auprès de laquelle l’information en cause a été obtenue.
+
+#### Licences
+
+Les Autorités administratives publient leurs Jeux de données sous Licence Ouverte ou ODbL, sauf homologation spécifique de licence (voir : https://www.data.gouv.fr/licences).
+
+Les autres Contributeurs publient leurs Jeux de données sous Licence Ouverte ou l’une des licences conformes à l’_open definition_ (voir : http://opendefinition.org/licenses).
+
+Les ressources des Jeux de données sont soumises à la licence choisie par le Contributeur publiant les données et affichée sur la page de chaque Jeu de données.
+
+### Publication de commentaire
+
+Les discussions ont vocation à porter sur le Jeu de données publié. Les Contributeurs ne publient pas de messages de nature publicitaire ou promotionnelle, à caractère raciste ou diffamatoire, grossier ou injurieux, agressif ou violent ou de façon générale qui contreviendrait aux bonnes mœurs, l’ordre public ou aux dispositions légales en vigueur.
+
+Les Contributeurs publiant un commentaire dans une discussion cèdent leurs droits de propriété intellectuelle sur ceux-ci de façon non exclusive, à titre gracieux, pour le monde entier, pour toute la durée de ces droits.
+
+### Utilisation de contact [info@data.gouv.fr](mailto:info@data.gouv.fr)
+
+L’adresse de contact permet de contacter Etalab et n’a pas pour objet de recevoir des demandes relatives à la situation individuelle d’un usager dans ses relations avec une Autorité administrative. Elle n’est pas non plus un moyen direct de contacter un Contributeur. Les Contributeurs peuvent être contactés via le formulaire de contact sur la page du Jeu de données concerné.
+
+## Engagements et responsabilités d’Etalab
+
+### Qualité de service et facilités offertes
+
+Etalab s’efforce de garantir la disponibilité de la plateforme 99,5 % du temps mensuel, apprécié au terme de chaque mois.
+
+Etalab propose, au choix du Contributeur, la publication de Jeux de données, via l’interface web de la plateforme, par l’intermédiaire d’une interface de programmation (API web) ou par le « moissonnage » de la plateforme du Contributeur (pour les sites compatibles).
+
+Etalab donne accès, au choix de l’Utilisateur, aux Jeux de données via l’interface web ou par l’intermédiaire d’une API web.
+
+Etalab s’engage à prendre toutes précautions utiles pour préserver l’intégrité des Jeux de données mis à disposition, et notamment empêcher qu’ils soient déformés ou endommagés.
+
+À la seule fin de garantir une meilleure information de l’Utilisateur, à travers un meilleur référencement, et sans jamais en dénaturer le sens, Etalab se réserve la possibilité de modifier les métadonnées associées à un Jeu de données.
+
+Etalab se réserve également la liberté de faire évoluer, de modifier ou de suspendre, sans préavis, la Plateforme pour des raisons de maintenance ou pour tout autre motif jugé nécessaire. L’indisponibilité de la Plateforme ne donne droit à aucune indemnité.
+
+### Responsabilités d’Etalab
+
+Etalab est responsable des contenus qu’Etalab propose afin d’animer la Plateforme.
+
+Etalab n’effectue pas de contrôle _a priori_ sur les publications des Autorités administratives ou des Contributeurs sur la Plateforme. Dès qu’Etalab a connaissance de contenus illicites, Etalab agit rapidement pour retirer ces données ou en rendre l’accès impossible. À cette fin, une procédure de signalement est mise en place sur la Plateforme. Tout Utilisateur peut signaler un contenu non conforme aux présentes conditions d’utilisation. Etalab se réserve notamment la possibilité de supprimer ou de rendre inaccessibles, sans préavis, les contributions sans lien avec l’activité de la Plateforme, publiées aux fins d’entraver le bon fonctionnement de la Plateforme, de publicité ou de promotion, de propagande ou de prosélytisme et toute contribution contrevenant aux lois et règlements en vigueur. Etalab se réserve également la possibilité de supprimer le profil d’un Contributeur et de refuser que certaines personnes aient accès à la plateforme, en cas de violation des présentes conditions d’utilisation.
+
+### Transparence sur le classement et mises en avant
+
+L’ordre de classement des Jeux de données issu du moteur de recherche de la Plateforme est issu d’un algorithme libre, dont [le code source est disponible ici](https://github.com/opendatateam/udata/tree/master/udata/search).
+
+Etalab choisit de mettre en avant certains contenus à travers les rubriques « L’Actu en données », « Jeux de données à la une » et « Meilleures Réutilisations », sur les pages d’accueil de la plateforme et des rubriques thématiques.
+
+### Contenus proposés par Etalab
+
+Les contenus proposés par Etalab sont sous [Licence Ouverte](https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf), à l’exception des logos et des représentations iconographiques et photographiques qui peuvent être régis par leurs licences propres.
+
+Le code source de la plateforme est libre et disponible ici : https://github.com/opendatateam/udata.
+
+### Évolution des conditions d’utilisation
+
+Les termes des présentes conditions d’utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
+
+## Vie privée
+
+### Cookies
+
+Le site dépose des cookies de mesure d’audience (nombre de visites, pages consultées), respectant les conditions d’exemption du consentement de l’internaute définies par la recommandation « Cookies » de la Commission nationale informatique et libertés (CNIL) ; il utilise Piwik, un outil libre, paramétré pour ce faire. Cela signifie, notamment, que ces cookies ne servent qu’à la production de statistiques anonymes et ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
+
+Le site dépose également des cookies de navigation, aux fins strictement techniques, qui ne sont pas conservés.
+
+La consultation de la Plateforme n’est pas affectée lorsque les Utilisateurs utilisent des navigateurs désactivant les cookies.
+
+### Données à caractère personnel
+
+La consultation des Jeux de données (y compris leur téléchargement) ne nécessite pas de s’inscrire, ni de s’authentifier.
+
+L’inscription à la Plateforme nécessite que l’Utilisateur communique à Etalab ses prénom et nom, ainsi que son courriel. Etalab s’engage à prendre toutes les mesures nécessaires permettant de garantir la sécurité et la confidentialité du courriel de l’Utilisateur. Celui-ci n’est jamais communiqué à des tiers, en dehors des cas prévus par la loi.
+
+La page de profil du Contributeur comprend ses prénom et nom et des éléments sur son activité (les pages suivies et les jeux de données publiés). Cette page n’est pas référencée par le moteur de recherche de la Plateforme.
+
+L’historique de consultation de l’Utilisateur n’est jamais rendu public, ni communiqué à des tiers, en dehors des cas prévus par la loi.
+
+En application de la loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, l’utilisateur dispose d’un droit d’accès, de rectification et d’opposition auprès d’Etalab. Ce droit s’exerce par courriel adressé à [contact@data.gouv.fr](mailto:contact@data.gouv.fr) ou par voie postale à Mission Etalab, 20 avenue de Ségur, 75334 PARIS Cedex 07.
+
+La Plateforme a été déclarée à la Commission nationale de l’informatique et des libertés (CNIL) sous le numéro : eRa0876341t.
+
+## Textes de référence
+
+[Livre III du code des relations entre le public et l’administration](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=2B8CFC0D49E08E4D1843153F6E476CA7.tpdila11v_2?idSectionTA=LEGISCTA000031367685&cidTexte=LEGITEXT000031366350&dateTexte=20170808)
+
+[Loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000886460)
+
+[Loi n° 2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000801164)
+
+[Loi n° 2016-1321 du 7 octobre 2016 pour une République numérique](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000033202746&categorieLien=id)
+
+Les textes d’organisation d’Etalab.
+
+## Mentions légales
+
+### Editeur
+
+Mission Etalab, Direction interministérielle du numérique et du système d’information et de communication de l’Etat (DINSIC).
+
+### Directrice de la publication
+
+M<sup>me</sup> Laure LUCCHESI, cheffe de la mission Etalab, Direction interministérielle du numérique et du système d’information et de communication de l’Etat (DINSIC).
+
+### Prestataire d’hébergement
+
+OVH
+
+RCS Roubaix – Tourcoing 424 761 419 00045
+
+Code APE 6202A
+
+N° TVA : FR 22 424 761 419
+
+Siège social : 2 rue Kellermann - 59100 Roubaix - France.
+
+[data.gouv.fr]: https://www.data.gouv.fr/

--- a/cgu.md
+++ b/cgu.md
@@ -94,7 +94,7 @@ Etalab propose deux types de certifications des organisations :
 - la certification de service public : elle identifie les Autorités administratives ;
 - la certification d’authenticité de l’organisation.
 
-Pour être certifiée, l’organisation en fait la demande par courriel à : [certification@data.gouv.fr](mailto:certification@data.gouv.fr).
+Pour être certifiée, [**l’organisation en fait la demande à l'équipe data.gouv.fr**](https://support.data.gouv.fr/collectivite-territoriale/certification)
 
 Cette certification permet notamment de bénéficier d’un meilleur classement dans les résultats du moteur de recherche de la plateforme. La certification d’une organisation n’emporte pas la certification des Jeux de données qu’elle met à disposition.
 

--- a/licences.md
+++ b/licences.md
@@ -1,0 +1,86 @@
+---
+title: Licences
+keywords:
+  - licences
+description: Licences de réutilisation des informations publiques.
+menu:
+  - footer
+---
+
+# Licences de réutilisation
+
+Afin d’éviter la prolifération des licences, la [loi pour une République numérique](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000033205142/2020-09-21/) a prévu la création d’une liste, fixée par décret, de licences qui peuvent être utilisées par les administrations pour la réutilisation à titre gratuit de leurs informations publiques, qu’il s’agisse de données ou de code source d’un logiciel ([article D.323-2-1 du code des relations entre le public et l’administration (CRPA)](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034504991&cidTexte=LEGITEXT000031366350&dateTexte=29991231)).
+
+La présente page référence toutes les licences utilisables à ce titre par les administrations. Elle pourra être tenue à jour au gré des évolutions de versions de ces textes, et des éventuelles évolutions du décret.
+
+La première partie de cette page dresse la liste des licences applicables aux informations publiques (données, documents…) ainsi qu’aux codes sources utilisables par l’administration.
+
+La deuxième partie de cette page dresse la liste des licences spéciales homologuées avec le périmètre applicable de l’homologation (information publique spécifique, administration spécifique, ou autre) au titre de l’[article D.323-2-2](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034504993&cidTexte=LEGITEXT000031366350&dateTexte=29991231) du CRPA.
+
+## Les licences pouvant être utilisées par les administrations
+
+### Les licences applicables aux « informations publiques » :
+| Licence établie par le Gouvernement                                                                                  | identifiant SPDX |
+|----------------------------------------------------------------------------------------------------------------------|------------------|
+| [Licence Ouverte version 2.0](https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf) | `etalab-2.0`     |
+
+| Licence avec obligation de partage à l’identique                                                    | identifiant SPDX |
+|-----------------------------------------------------------------------------------------------------|------------------|
+| [ODC Open Database License (ODbL) version 1.0](https://spdx.org/licenses/ODbL-1.0.html#licenseText) | `ODbL-1.0`       |
+
+### Les licences applicables spécifiquement aux codes source de logiciels :
+
+| Licences permissives                                                                               | identifiant SPDX |
+|----------------------------------------------------------------------------------------------------|------------------|
+| [Apache License 2.0](https://spdx.org/licenses/Apache-2.0.html#licenseText)                        | `Apache-2.0`     |
+| [BSD 2-Clause "Simplified" License](https://spdx.org/licenses/BSD-2-Clause.html#licenseText)       | `BSD-2-Clause`   |
+| [BSD 3-Clause "New" or "Revised" License](https://spdx.org/licenses/BSD-3-Clause.html#licenseText) | `BSD-3-Clause`   |
+| [CeCILL-B Free Software License Agreement](https://spdx.org/licenses/CECILL-B.html#licenseText)    | `CECILL-B`       |
+| [MIT License](https://spdx.org/licenses/MIT.html#licenseText)                                      | `MIT`            |
+
+| Licences avec obligation de réciprocité                                                                         | identifiant SPDX    |
+|-----------------------------------------------------------------------------------------------------------------|---------------------|
+| [CeCILL Free Software License Agreement v2.1](https://spdx.org/licenses/CECILL-2.1.html#licenseText)            | `CECILL-2.1`        |
+| [CeCILL-C Free Software License Agreement](https://spdx.org/licenses/CECILL-C.html#licenseText)                 | `CECILL-C`          |
+| [GNU General Public License v3.0 or later](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText)         | `GPL-3.0-or-later`  |
+| [GNU Lesser General Public License v3.0 or later](https://spdx.org/licenses/LGPL-3.0-or-later.html#licenseText) | `LGPL-3.0-or-later` |
+| [GNU Affero General Public License v3.0 or later](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText) | `AGPL-3.0-or-later` |
+| [Mozilla Public License 2.0](https://spdx.org/licenses/MPL-2.0.html#licenseText)                                | `MPL-2.0`           |
+
+ Il est précisé que l’obligation faite aux administrations de choisir parmi ces licences ne vaut que lorsque les administrations peuvent établir une licence de réutilisation. En particulier, les administrations participant à un projet déjà initié sous une licence déjà imposée ont bien entendu la faculté de contribuer au projet sous cette licence ([plus de détails](https://www.etalab.gouv.fr/licence-version-2-0-de-la-licence-ouverte-suite-a-la-consultation-et-presentation-du-decret)). 
+ 
+ 
+## Les licences homologuées
+
+Les administrations souhaitant recourir à une licence ne figurant pas dans le paragraphe précédent doivent auparavant en obtenir l’homologation dans les conditions prévues à l’[article D.323-2-2](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034504993&cidTexte=LEGITEXT000031366350&dateTexte=29991231) du CRPA.
+
+Pour être prononcée, une homologation doit suivre une procédure particulière. L’administration (services de l’État, collectivité, établissement public…) doit pour cela contacter la mission Etalab (homologation.licence@data.gouv.fr).
+
+La demande d’homologation doit comporter :
+
+1.  La description des informations publiques (données, logiciel…) dont la réutilisation doit être spécialement encadrée,
+2.  Les raisons motivées de cette volonté d’encadrement spécifique,
+3.  Les explications montrant l’inadéquation des licences proposées,
+4.  Le texte de la licence souhaitée,
+5.  La synthèse de la concertation menée auprès des réutilisateurs,
+
+Une fois homologuée, la licence s’applique aux seules informations publiques (données, logiciels…) concernées par la demande originale.
+
+La liste ci-dessous présente les licences homologuées, le périmètre et la durée de l'homologation :
+
+*   La **« [licence d’utilisation à titre gratuit](https://static.data.gouv.fr/static/gouvfr/licences/licence-d-utilisation-a-titre-gratuit-de-l-IGN-2017-05-05.pdf) »** de l’institut national géographique et forestier (IGN) est homologuée par la [décision d'homologation](https://static.data.gouv.fr/static/gouvfr/licences/homologation-licences-2019-05-29.pdf) du 29 mai 2019 pour le périmètre des données géographiques BD ORTHO®, BD TOPO®, BD PARCELLAIRE®, BD ADRESSE® et RGE ALTI® jusqu'au 31 décembre 2021.
+*   La **[licence du produit gratuit issu de la Base Adresse Nationale (BAN)](https://static.data.gouv.fr/static/gouvfr/licences/licence-du-produit-gratuit-issu-de-la-Base-Adresse-Nationale-2019-05-29.pdf)** est homologuée par la [décision d'homologation](https://static.data.gouv.fr/static/gouvfr/licences/homologation-licences-2019-05-29.pdf) du 29 mai 2019 pour les données figurant dans la [description du contenu](https://static.data.gouv.fr/static/gouvfr/licences/description-contenu.pdf) du produit gratuit issu de la Base Adresse Nationale (BAN) jusqu'au 31 décembre 2019.
+*   La licence **« [Creative Commons Attribution - Partage dans les mêmes conditions (CC-BY-SA) 4.0](https://creativecommons.org/licenses/by-sa/4.0/legalcode.fr) »** est homologuée par la [décision d'homologation](https://static.data.gouv.fr/static/gouvfr/licences/homologation-licences-2017-09-29.pdf) du 26 septembre 2017 pour le périmètre des levés bathymétriques, dalles bathymétriques, natures de fonds, délimitations maritimes, câbles et conduites sous-marines, toponymes, et épaves et obstructions du Service hydrographique et océanographique de la marine (SHOM) jusqu'au 25 septembre 2020.
+*   La **[licence de réutilisation des informations de l'institut National de la Propriété Industrielle (INPI)](https://static.data.gouv.fr/static/gouvfr/licences/licence-de-reutilisation-des-informations-de-l-INPI-pour-les-donnees-de-PI-2019-04-17.pdf)** est homologuée par la [décision d'homologation](https://static.data.gouv.fr/static/gouvfr/licences/homologation-licences-2019-04-17.pdf) du 17 avril 2019 pour les données des bases Marques françaises, Brevets français et européens, Dessins et modèles, Jurisprudence judiciaire française, et Décisions d'opposition de l'INPI jusqu'au 16 avril 2022.
+*   La **[licence de réutilisation des informations de l'institut National de la Propriété Industrielle (INPI)](https://static.data.gouv.fr/static/gouvfr/licences/licence-de-reutilisation-des-informations-de-l-INPI-pour-les-donnees-du-RNCS-2019-04-17.pdf)** est homologuée par la [décision d'homologation](https://static.data.gouv.fr/static/gouvfr/licences/homologation-licences-2019-04-17.pdf) du 17 avril 2019 pour les données du Registre National du Commerce et des Sociétés de l'INPI jusqu'au 16 avril 2022.
+
+## Références :
+
+*   [La loi pour une République numérique](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000033205142/2020-09-21/)
+*   [Article D.323-2-1 du code des relations entre le public et l’administration (CRPA)](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034504991&cidTexte=LEGITEXT000031366350&dateTexte=29991231)
+*   [Article D.323-2-2 du code des relations entre le public et l’administration (CRPA)](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034504993&cidTexte=LEGITEXT000031366350&dateTexte=29991231)
+
+## Pour plus de détails sur les licences libres :
+
+*   [La page de l’Open Source Initiative](https://opensource.org/licenses)
+*   [La page de la Free Software Foundation](https://www.gnu.org/licenses/license-list.fr.html)

--- a/licences.md
+++ b/licences.md
@@ -54,7 +54,7 @@ La deuxième partie de cette page dresse la liste des licences spéciales homolo
 
 Les administrations souhaitant recourir à une licence ne figurant pas dans le paragraphe précédent doivent auparavant en obtenir l’homologation dans les conditions prévues à l’[article D.323-2-2](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034504993&cidTexte=LEGITEXT000031366350&dateTexte=29991231) du CRPA.
 
-Pour être prononcée, une homologation doit suivre une procédure particulière. L’administration (services de l’État, collectivité, établissement public…) doit pour cela contacter la mission Etalab (homologation.licence@data.gouv.fr).
+Pour être prononcée, une homologation doit suivre une procédure particulière. L’administration (services de l’État, collectivité, établissement public…) doit pour cela [**contacter la mission Etalab**](https://support.data.gouv.fr/administration-centrale/licence) .
 
 La demande d’homologation doit comporter :
 

--- a/redevances.md
+++ b/redevances.md
@@ -1,0 +1,49 @@
+---
+title: Redevances
+keywords:
+  - redevances
+description: Comment fonctionnent les redevances de réutilisation d'informations publiques établies ?
+menu:
+  - footer
+---
+
+# Redevances
+
+## La gratuité est la règle et les redevances l'exception
+En matière de réutilisation des informations publiques, **le principe est celui de la gratuité** (voir l'article [L. 324-1](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=66430676A901E0DF88843D1627404BAB.tplgfr31s_1?idArticle=LEGIARTI000033219051&cidTexte=LEGITEXT000031366350&dateTexte=20170808) du code des relations entre le public et l’administration (CRPA)).
+
+Par exception, **des redevances ne peuvent être perçues que dans deux cas :**
+
+-   Pour les administrations dont l'activité principale consiste en la collecte, la production, la mise à disposition ou la diffusion d'informations publiques, lorsque la couverture des coûts liés à cette activité principale est assurée à moins de 75 % par des recettes fiscales, des dotations ou des subventions (soit à au moins 25% par des recettes propres). Pour les administrations relevant de l’Etat (y compris ses établissements publics administratifs), une liste stricte des données susceptibles d'être soumises à une redevance de réutilisation est publiée ([D. 324-5-1 CRPA)](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=B9291B63BE1EF1131C188EAF0FA76744.tpdila11v_2?idArticle=LEGIARTI000033504821&cidTexte=LEGITEXT000031366350&dateTexte=20170808). Cette liste est rappelée ci-dessous.
+-   Pour les bibliothèques, y compris les bibliothèques universitaires, les musées et les archives, uniquement pour les informations issues d’opérations de numérisation de leurs fonds et collections et, le cas échéant, les informations qui y sont associées, lorsque ces dernières sont commercialisées conjointement ([art. L. 324-2 CRPA](https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000033219083&dateTexte=&categorieLien=id)). En bref, les redevances ne peuvent porter que sur la réutilisation des fichiers-images numérisés ainsi que sur leurs métadonnées (si elles sont réutilisées conjointement avec ceux-ci) ; les redevances ne peuvent concerner des documents nativement numériques.
+
+A noter : l’INSEE et les services statistiques ministériels ne peuvent plus demander de redevances pour réutilisation de leurs données ([art. L. 324-6 CRPA](https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000033219083&dateTexte=&categorieLien=id)).
+
+> **Toutes les redevances perçues antérieurement ne se conformant pas au cadre légal désormais en vigueur ne peuvent plus être exigées.** [La Commission d'accès aux documents administratifs (CADA)](http://www.cada.fr/) est compétente en matière de demande de réutilisation, y compris sur les questions de licences et de redevances.
+
+## Quel montant pour les redevances de réutilisation
+Le produit total du montant des redevances perçues sur un an pour un jeu de données ne dépasse pas les coûts qui lui sont liés tels que décrits dans ce tableau :
+
+|                        | Je suis une administration dédiée à l’information publique                                                                                     | Je suis une institution culturelle réalisant des numérisations                                                                                                                                                                                                                                                                                     |
+|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Périmètre              | Coûts de collecte, de production, de mise à la disposition ou de diffusion en ligne (y compris, le cas échéant, coûts d’anonymisation)         | Coûts de collecte, de production, de mise à disposition ou de diffusion en ligne (y compris, le cas échéant, coûts d’anonymisation), de conservation et d'acquisition des droits de propriété intellectuelle sur les informations publiques. <br>Attention : il ne s’agit jamais des coûts de collecte et de conservation des documents originaux. |
+| Période max d'assiette | Coûts moyens sur les trois derniers exercices budgétaires ou comptables                                                                        | Coûts moyens sur les trois derniers exercices budgétaires ou comptables pour la conservation et la mise à disposition-diffusion.<br>Coûts moyens sur les dix derniers exercices budgétaires ou comptables pour les coûts de numérisation et d'acquisition des droits de propriété intellectuelle.                                                  |
+
+
+Le montant des redevances est fixé selon des critères objectifs, transparents, vérifiables et non discriminatoires. Ce montant est **révisé au moins tous les cinq ans**. Les modalités de son calcul sont **publiées sous forme électronique conjointement sur le site internet de l'administration concernée et sur cette page.**
+
+## Transparence sur les redevances de réutilisation pratiquées
+Conformément aux articles [R. 324-4-5](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=B89C3CC9C0E113117A383292CE5CFB9C.tpdila11v_2?idArticle=LEGIARTI000032951707&cidTexte=LEGITEXT000031366350&dateTexte=20170808) et [R. 324-6-1](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=74B58B7E6B5A7C0424C31016DB61A062.tplgfr31s_1?idArticle=LEGIARTI000032258099&cidTexte=LEGITEXT000031366350&dateTexte=20160329) du code des relations du public et de l’administration, la mission Etalab rend publique :
+
+-   la liste des informations ou catégories d'informations détenues par l’Etat, y compris ses établissements publics, dont la réutilisation peut être soumise à redevance ;
+-   la liste des redevances de réutilisation pratiquées par les administrations, avec leurs modalités de calcul.
+
+> Si vous avez créé (ou maintenu) une redevance, faites-en parvenir le barème de calcul à la mission Etalab pour publication sur cette page à : info@data.gouv.fr.
+
+## Administrations dédiées à la diffusion d'informations publiques
+-   Institut national de l'information géographique et forestière : [lien vers les modalités de calcul](http://professionnels.ign.fr/doc/Bar%C3%A8me%20des%20licencesdExploitations2017.pdf)
+-   Météo-France : [lien vers les modalités de calcul](https://donneespubliques.meteofrance.fr/client/gfx/utilisateur/File/Redevances_Portail_DonneesPubliques.pdf)
+-   Service hydrographique et océanographique de la marine : [lien vers les modalités de calcul](http://diffusion.shom.fr/media/wysiwyg/catalogues/repertoire_2017_web.pdf)
+
+## Administrations pratiquant des opérations de numérisation
+_Aucune administration n’a transmis de modalités de calcul._

--- a/reference.md
+++ b/reference.md
@@ -1,0 +1,68 @@
+---
+title: Service Public de la Donnée
+keywords:
+  - service public de la donnée
+  - données reference
+description: Service Public de la donnée de référence, des données sur lesquelles vous pouvez compter.
+menu:
+  - footer
+  
+datasets:
+  - base-adresse-nationale
+  - base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret
+  - code-officiel-geographique-cog
+  - plan-cadastral-informatise
+  - registre-parcellaire-graphique-rpg-contours-des-parcelles-et-ilots-culturaux-et-leur-groupe-de-cultures-majoritaire
+  - referentiel-de-lorganisation-administrative-de-letat
+  - referentiel-a-grande-echelle-rge
+  - repertoire-national-des-associations
+  - repertoire-operationnel-des-metiers-et-des-emplois-rome
+---
+
+# Service public de la donnée : des données sur lesquelles vous pouvez compter
+Le service public de la donnée créé par [l’Article 14 de la loi pour une République numérique](https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000033202746&idArticle=JORFARTI000033203033&categorieLien=cid) vise à mettre à disposition, en vue de faciliter leur réutilisation, les jeux de données de référence qui présentent le plus fort impact économique et social. Il s’adresse principalement aux entreprises et aux administrations pour qui la disponibilité d’une donnée de qualité est critique. Les producteurs et les diffuseurs prennent des engagements auprès de ces utilisateurs. La mission Etalab est chargée de la mise en oeuvre et de la gouvernance de ce nouveau service public. Elle référence l’ensemble des données concernées sur cette page.
+
+## Les données de référence
+À ce jour, neuf jeux de données, qui couvrent un large champ thématique ont été identifiés comme des données de référence.
+
+- [Base Adresse Nationale (BAN)](https://www.data.gouv.fr/fr/datasets/base-adresse-nationale/)
+- [Base Sirene des entreprises et de leurs établissements (SIREN, SIRET)](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/)
+- [Code Officiel Géographique (COG)](https://www.data.gouv.fr/fr/datasets/code-officiel-geographique-cog/)
+- [Plan Cadastral Informatisé](https://www.data.gouv.fr/fr/datasets/plan-cadastral-informatise/)
+- [Registre parcellaire graphique (RPG) : contours des parcelles et îlots culturaux et leur groupe de cultures majoritaire](https://www.data.gouv.fr/fr/datasets/registre-parcellaire-graphique-rpg-contours-des-parcelles-et-ilots-culturaux-et-leur-groupe-de-cultures-majoritaire/)
+- [Référentiel de l'organisation administrative de l'Etat](https://www.data.gouv.fr/fr/datasets/referentiel-de-lorganisation-administrative-de-letat/)
+- [Référentiel à grande échelle (RGE)](https://www.data.gouv.fr/fr/datasets/referentiel-a-grande-echelle-rge/)
+- [Répertoire National des Associations (RNA)](https://www.data.gouv.fr/fr/datasets/repertoire-national-des-associations/)
+- [Répertoire Opérationnel des Métiers et des Emplois (ROME)](https://www.data.gouv.fr/fr/datasets/repertoire-operationnel-des-metiers-et-des-emplois-rome/)
+
+## L’organisation du service public de la donnée
+Elle est déterminée par le décret d’application [2017-331](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000034194946&categorieLien=id) du 14 mars 2017 relatif au service public de mise à disposition des données de référence.
+
+**Les producteurs** produisent la donnée de référence et documentent les métadonnées.  
+Ils traitent les remontées des utilisateurs ou le cas échéant, orientent les utilisateurs vers le service compétent pour traiter ces demandes.  
+Ils prennent des engagements sur la mise à jour des données.  
+Ils désignent les diffuseurs pour chacun des jeux de données de référence.
+
+**Les diffuseurs** mettent à disposition les données avec un haut niveau de qualité.  
+Ils s’engagent sur des niveaux de performance et de disponibilité.
+
+**Les utilisateurs** utilisent les données de référence pour produire de nouveaux services et créer de la valeur économique et sociale.  
+Ils participent à la montée en qualité des données de référence (signalement des erreurs, propositions d’amélioration).
+
+**La mission Etalab**, en charge du portail data.gouv.fr recense l’ensemble des jeux de données de référence.  
+Elle gère le service public de la donnée en lien avec les producteurs.  
+Elle anime le dispositif et en assure la promotion auprès des utilisateurs.  
+Elle développe des outils mutualisables, notamment sur la montée en qualité des données.
+
+Par ailleurs, en cas de défaillance des diffuseurs, ou de non-respect des engagements notamment en matière de performance et de disponibilité, la mission Etalab est habilitée à se substituer au diffuseur désigné par le producteur.
+
+## Les prochaines étapes
+Le service public de la donnée se construit progressivement, dans un mode itératif avec les producteurs et les utilisateurs. Chaque producteur doit publier ses engagements sur les conditions de la mise à disposition (documentation des données, fréquence de mise à jour, performance et disponibilité de la mise à disposition).
+
+La mission Etalab publiera sur ce site les indicateurs de disponibilité des données, et assurera plus généralement le suivi du respect de ces engagements.
+
+## Références
+-   [L’article L321-4 du Code des relations entre le public et les administrations](https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000033205649&dateTexte=29990101&categorieLien=cid)
+-   [Le décret d’application 2017-331 du 14 mars 2017 relatif au service public de mise à disposition des données de référence](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000034194946&categorieLien=id)
+-   [L'arrêté du 14 juin 2017 relatif aux règles techniques et d'organisation de mise à disposition des données de référence prévues à l'article L. 321-4 du code des relations entre le public et l'administration](https://www.legifrance.gouv.fr/eli/arrete/2017/6/14/PRMJ1713859A/jo/texte)
+-   [La synthèse de la consultation publique organisée par Etalab en octobre 2016](http://www.etalab.gouv.fr/consultation-spd)

--- a/reference.md
+++ b/reference.md
@@ -25,15 +25,15 @@ Le service public de la donnée créé par [l’Article 14 de la loi pour une R�
 ## Les données de référence
 À ce jour, neuf jeux de données, qui couvrent un large champ thématique ont été identifiés comme des données de référence.
 
-- [Base Adresse Nationale (BAN)](https://www.data.gouv.fr/fr/datasets/base-adresse-nationale/)
-- [Base Sirene des entreprises et de leurs établissements (SIREN, SIRET)](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/)
-- [Code Officiel Géographique (COG)](https://www.data.gouv.fr/fr/datasets/code-officiel-geographique-cog/)
-- [Plan Cadastral Informatisé](https://www.data.gouv.fr/fr/datasets/plan-cadastral-informatise/)
-- [Registre parcellaire graphique (RPG) : contours des parcelles et îlots culturaux et leur groupe de cultures majoritaire](https://www.data.gouv.fr/fr/datasets/registre-parcellaire-graphique-rpg-contours-des-parcelles-et-ilots-culturaux-et-leur-groupe-de-cultures-majoritaire/)
-- [Référentiel de l'organisation administrative de l'Etat](https://www.data.gouv.fr/fr/datasets/referentiel-de-lorganisation-administrative-de-letat/)
-- [Référentiel à grande échelle (RGE)](https://www.data.gouv.fr/fr/datasets/referentiel-a-grande-echelle-rge/)
-- [Répertoire National des Associations (RNA)](https://www.data.gouv.fr/fr/datasets/repertoire-national-des-associations/)
-- [Répertoire Opérationnel des Métiers et des Emplois (ROME)](https://www.data.gouv.fr/fr/datasets/repertoire-operationnel-des-metiers-et-des-emplois-rome/)
+- [Base Adresse Nationale (BAN)](/datasets/base-adresse-nationale/)
+- [Base Sirene des entreprises et de leurs établissements (SIREN, SIRET)](/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/)
+- [Code Officiel Géographique (COG)](/datasets/code-officiel-geographique-cog/)
+- [Plan Cadastral Informatisé](/datasets/plan-cadastral-informatise/)
+- [Registre parcellaire graphique (RPG) : contours des parcelles et îlots culturaux et leur groupe de cultures majoritaire](/datasets/registre-parcellaire-graphique-rpg-contours-des-parcelles-et-ilots-culturaux-et-leur-groupe-de-cultures-majoritaire/)
+- [Référentiel de l'organisation administrative de l'Etat](/datasets/referentiel-de-lorganisation-administrative-de-letat/)
+- [Référentiel à grande échelle (RGE)](/datasets/referentiel-a-grande-echelle-rge/)
+- [Répertoire National des Associations (RNA)](/datasets/repertoire-national-des-associations/)
+- [Répertoire Opérationnel des Métiers et des Emplois (ROME)](/datasets/repertoire-operationnel-des-metiers-et-des-emplois-rome/)
 
 ## L’organisation du service public de la donnée
 Elle est déterminée par le décret d’application [2017-331](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000034194946&categorieLien=id) du 14 mars 2017 relatif au service public de mise à disposition des données de référence.

--- a/suivi.md
+++ b/suivi.md
@@ -1,0 +1,29 @@
+---
+title: Suivi d'audience et vie privée
+keywords:
+  - suivi
+  - cookies
+description: Suivi d'audience et vie privée sur data.gouv.fr
+menu:
+  - footer
+---
+
+# Suivi d'audience et vie privée
+
+## Cookies déposés et opt-out
+
+Ce site dépose un petit fichier texte (un « cookie ») sur votre ordinateur lorsque vous le consultez. Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.
+
+
+<iframe class="optout" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr"></iframe>
+
+
+## Ce site n'affiche pas de bannière de consentement aux cookies, pourquoi ?
+
+Nous respectons simplement la loi, qui dit que certains outils de suivi d'audience, correctement configurés pour respecter la vie privée, sont exemptés d'autorisation préalable.
+
+Nous utilisons pour cela [Matomo](https://matomo.org), un outil [libre](https://matomo.org/free-software/), paramétré pour être en conformité avec la [recommandation « Cookies »](https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience) de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d'être enregistrée. Il est donc impossible d'associer vos visites sur ce site à votre personne.
+
+## Je contribue à enrichir vos données, puis-je y accéder ?
+
+Bien sûr ! Les statistiques d’usage sont disponibles en accès libre sur [stats.data.gouv.fr](https://stats.data.gouv.fr).


### PR DESCRIPTION
Following https://github.com/etalab/data.gouv.fr/issues/216, the objective is to migrate the existing static pages on data.gouv.fr to the markdown format that is currently used for inventory pages.