### PR TITLE
Changed absolute URLs to relative ones

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,77 @@
+# LICENCE OUVERTE 2.0 / OPEN LICENCE 2.0
+
+## « Réutilisation » de l'« Information » sous cette licence
+
+Le « Concédant » concède au « Réutilisateur » un droit non exclusif et gratuit de libre « Réutilisation » de l'« Information » objet de la présente licence, à des fins commerciales ou non, dans le monde entier et pour une durée illimitée, dans les conditions exprimées ci-dessous.
+
+**Le « Réutilisateur » est libre de réutiliser l'« Information » :**
+
+- de la reproduire, la copier,
+- de l‘adapter, la modifier, l‘extraire et la transformer, pour créer des « Informations dérivées », des produits ou des services,
+- de la communiquer, la diffuser, la redistribuer, la publier et la transmettre,
+- de l'exploiter à titre commercial, par exemple en la combinant avec d'autres informations, ou en l'incluant dans son propre produit ou application.
+
+**Sous réserve de :**
+
+- mentionner la paternité de l'« Information » : sa source (au moins le nom du « Concédant ») et la date de dernière mise à jour de l'« Information » réutilisée.
+
+Le « Réutilisateur » peut notamment s'acquitter de cette condition en renvoyant, par un lien hypertexte, vers la source de «l'Information» et assurant une mention effective de sa paternité.
+Par exemple : *« Ministère de xxx - Données originales téléchargées sur http://www.data.gouv.fr/fr/datasets/xxx/, mise à jour du 14 février 2017 »*.
+
+Cette mention de paternité ne confère aucun caractère officiel à la « Réutilisation » de l'« Information », et ne doit pas suggérer une quelconque reconnaissance ou caution par le « Concédant », ou par toute autre entité publique, du « Réutilisateur » ou de sa « Réutilisation ».
+
+## « Données à caractère personnel »
+
+L‘ « Information » mise à disposition peut contenir des « Données à caractère personnel » pouvant faire l'objet d'une « Réutilisation ». Si tel est le cas, le « Concédant » informe le « Réutilisateur » de leur présence. L' « Information » peut être librement réutilisée, dans le cadre des droits accordés par la présente licence, à condition de respecter le cadre légal relatif à la protection des données à caractère personnel.
+
+## « Droits de propriété intellectuelle »
+
+Il est garanti au « Réutilisateur » que les éventuels « Droits de propriété intellectuelle » détenus par des tiers ou par le « Concédant » sur l'« Information » ne font pas obstacle aux droits accordés par la présente licence.
+
+Lorsque le « Concédant » détient des « Droits de propriété intellectuelle » cessibles sur l'« Information », il les cède au « Réutilisateur » de façon non exclusive, à titre gracieux, pour le monde entier, pour toute la durée des « Droits de propriété intellectuelle », et le « Réutilisateur » peut faire tout usage de l'« Information » conformément aux libertés et aux conditions définies par la présente licence.
+
+## Responsabilité
+
+L' « Information » est mise à disposition telle que produite ou reçue par le « Concédant », sans autre garantie expresse ou tacite que celles prévues par la présente licence. L'absence de défauts ou d'erreurs éventuellement contenues dans l'« Information », comme la fourniture continue de l'« Information » n'est pas garantie par le « Concédant ». Il ne peut être tenu pour responsable de toute perte, préjudice ou dommage de quelque sorte causé à des tiers du fait de la « Réutilisation ».
+
+Le « Réutilisateur » est seul responsable de la « Réutilisation » de l'« Information ».
+
+La « Réutilisation » ne doit pas induire en erreur des tiers quant au contenu de l'« Information », sa source et sa date de mise à jour.
+
+## Droit applicable
+
+La présente licence est régie par le droit français.
+
+## Compatibilité de la présente licence
+
+La présente licence a été conçue pour être compatible avec toute licence libre qui exige au moins la mention de paternité et notamment avec la version antérieure de la présente licence ainsi qu'avec les licences « Open Government Licence » (OGL) du Royaume-Uni, « Creative Commons Attribution » (CC-BY) de Creative Commons et « Open Data Commons Attribution » (ODC-BY) de l'Open Knowledge Foundation.
+
+## Définitions
+
+Sont considérés, au sens de la présente licence comme :
+
+- Le **« Concédant »** : toute personne concédant un droit de « Réutilisation » sur l'« Information » dans les libertés et les conditions prévues par la présente licence
+- L'**« Information »** :
+  - toute information publique figurant dans des documents communiqués ou publiés par une administration mentionnée au premier alinéa de l'article L.300-2 du CRPA ;
+  - toute information mise à disposition par toute personne selon les termes et conditions de la présente licence.
+- La **« Réutilisation »** : l'utilisation de l'« Information » à d'autres fins que celles pour lesquelles elle a été produite ou reçue.
+- Le **« Réutilisateur »** : toute personne qui réutilise les « Informations » conformément aux conditions de la présente licence.
+- Des **« Données à caractère personnel »** : toute information se rapportant à une personne physique identifiée ou identifiable, pouvant être identifiée directement ou indirectement. Leur « Réutilisation » est subordonnée au respect du cadre juridique en vigueur.
+- Une **« Information dérivée »** : toute nouvelle donnée ou information créées directement à partir de l'« Information » ou à partir d'une combinaison de l'« Information » et d'autres données ou informations non soumises à cette licence.
+- Les **« Droits de propriété intellectuelle »** : tous droits identifiés comme tels par le Code de la propriété intellectuelle (notamment le droit d'auteur, droits voisins au droit d'auteur, droit sui generis des producteurs de bases de données…).
+
+## À propos de cette licence
+
+La présente licence a vocation à être utilisée par les administrations pour la réutilisation de leurs informations publiques. Elle peut également être utilisée par toute personne souhaitant mettre à disposition de l'« Information » dans les conditions définies par la présente licence
+
+La France est dotée d'un cadre juridique global visant à une diffusion spontanée par les administrations de leurs informations publiques afin d'en permettre la plus large réutilisation.
+
+Le droit de la « Réutilisation » de l'« Information » des administrations est régi par le code des relations entre le public et l'administration (CRPA).
+
+Cette licence facilite la réutilisation libre et gratuite des informations publiques et figure parmi les licences qui peuvent être utilisées par l'administration en vertu du décret pris en application de l'article L.323-2 du CRPA.
+
+Etalab est la mission chargée, sous l'autorité du Premier ministre, d'ouvrir le plus grand nombre de données publiques des administrations de l'État et de ses établissements publics. Elle a réalisé la Licence Ouverte pour faciliter la réutilisation libre et gratuite de ces informations publiques, telles que définies par l'article L321-1 du CRPA.
+
+Cette licence est la version 2.0 de la Licence Ouverte.
+
+Etalab se réserve la faculté de proposer de nouvelles versions de la Licence Ouverte. Cependant, les « Réutilisateurs » pourront continuer à réutiliser les informations qu'ils ont obtenues sous cette licence s'ils le souhaitent.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# datagouvfr-pages
+
+Ce dépôt contient les fichiers qui alimentent [les pages inventaire du portail data.gouv.fr](https://www.data.gouv.fr/fr/pages/donnees-cles-par-sujet).
+
+Les pages sont écrites en [GitHub Flavored Markdown](https://github.github.com/gfm/), avec un en-tête spécifique pour ajouter des jeux de données et des réutilisations.
+Pour plus d'informations techniques sur les pages inventaire, consulter [cette pull request dans le dépôt de udata-gouvfr](https://github.com/etalab/udata-gouvfr/pull/483).
+
+## Pages inventaire actuellement publiées
+- [Les données relatives au COVID-19](https://www.data.gouv.fr/fr/pages/donnees-coronavirus)
+- [Les données des élections](https://www.data.gouv.fr/fr/pages/donnees-des-elections)
+- [Les données relatives aux associations et aux fondations](https://www.data.gouv.fr/fr/pages/donnees-associations-fondations)
+- [Les données relatives aux comptes publics](https://www.data.gouv.fr/fr/pages/donnees-comptes-publics)

--- a/pages/donnees-associations-fondations.md
+++ b/pages/donnees-associations-fondations.md
@@ -28,71 +28,71 @@ datasets:
 
 ### Données de référence et répertoires
 
-- [Répertoire National des Associations RNA](https://www.data.gouv.fr/fr/datasets/repertoire-national-des-associations/) par le [Ministère de l'Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
-- [Base Sirene des entreprises et de leurs établissements (SIREN, SIRET)](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/) par [l'INSEE](https://www.data.gouv.fr/fr/organizations/institut-national-de-la-statistique-et-des-etudes-economiques-insee/)
+- [Répertoire National des Associations RNA](/datasets/repertoire-national-des-associations/) par le [Ministère de l'Intérieur](/organizations/ministere-de-l-interieur/)
+- [Base Sirene des entreprises et de leurs établissements (SIREN, SIRET)](/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/) par [l'INSEE](/organizations/institut-national-de-la-statistique-et-des-etudes-economiques-insee/)
 
-#### Par le [Ministère de l'Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+#### Par le [Ministère de l'Intérieur](/organizations/ministere-de-l-interieur/)
 
-- [Associations Reconnues d'Utilité Publique ARUP](https://www.data.gouv.fr/fr/datasets/associations-reconnues-d-utilite-publique/)
-- [Fondations Reconnues d'Utilité Publique](https://www.data.gouv.fr/fr/datasets/fondations-reconnues-d-utilite-publique/) 
+- [Associations Reconnues d'Utilité Publique ARUP](/datasets/associations-reconnues-d-utilite-publique/)
+- [Fondations Reconnues d'Utilité Publique](/datasets/fondations-reconnues-d-utilite-publique/) 
 
-#### Par les [services du Premier Ministre]((https://www.data.gouv.fr/fr/organizations/premier-ministre/)
+#### Par les [services du Premier Ministre]((/organizations/premier-ministre/)
 
-- [Associations - Journal Officiel (JOAFE)](https://www.data.gouv.fr/fr/datasets/associations-joafe/)
-- [Comptes annuels des associations, fondations et fonds de dotation](https://www.data.gouv.fr/fr/datasets/comptes-associations/)
-- [Service-public.fr- Guide « vos droits et démarches » Associations](https://www.data.gouv.fr/fr/datasets/service-public-fr-guide-vos-droits-et-demarches-associations/)
+- [Associations - Journal Officiel (JOAFE)](/datasets/associations-joafe/)
+- [Comptes annuels des associations, fondations et fonds de dotation](/datasets/comptes-associations/)
+- [Service-public.fr- Guide « vos droits et démarches » Associations](/datasets/service-public-fr-guide-vos-droits-et-demarches-associations/)
 
 Voir aussi :
 
-- [Le répertoire des associations de personnes handicapées](https://www.data.gouv.fr/fr/datasets/associations-de-personnes-handicapees/#_) par [l'ONISEP](https://www.data.gouv.fr/fr/organizations/office-national-d-information-sur-les-enseignements-et-les-professions/)
+- [Le répertoire des associations de personnes handicapées](/datasets/associations-de-personnes-handicapees/#_) par [l'ONISEP](/organizations/office-national-d-information-sur-les-enseignements-et-les-professions/)
 
 ### Données de la commande publique
 
-- [Fichiers consolidés des données essentielles de la commande publique DECP](https://www.data.gouv.fr/fr/datasets/fichiers-consolides-des-donnees-essentielles-de-la-commande-publique/) par Etalab
+- [Fichiers consolidés des données essentielles de la commande publique DECP](/datasets/fichiers-consolides-des-donnees-essentielles-de-la-commande-publique/) par Etalab
 
 ### Données relatives aux subventions aux associations
 
 #### Par le Ministère de l'Economie et des Finances
 
-- [Projet de loi de finances pour 2021 (PLF 2021), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2021-plf-2021-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
-- [Projet de loi de finances pour 2020 (PLF 2020), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
-- [Projet de loi de finances pour 2019 (PLF 2019), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2019-plf-2019-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
-- [Projet de loi de finances pour 2018 (PLF 2018), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2018-plf-2018-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations-1/)
-- [Projet de loi de finances pour 2017 (PLF 2017), jaune effort financier de l’État en faveur des associations](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2017-plf-2017-jaune-effort-financier-de-letat-en-faveur-des-associations/#_)
-- [Projet de loi de finances pour 2016 (PLF 2016), jaune effort financier de l’État en faveur des associations](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2016-plf-2016-jaune-effort-financier-de-letat-en-faveur-des-associations/)
-- [Projet de loi de finances pour 2015 (PLF 2015), jaune effort financier de l’État en faveur des associations](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2015-plf-2015-jaune-effort-financier-de-letat-en-faveur-des-associations/)
-- [PLF - Jaune - Associations subventionnées 2010 - 2012](https://www.data.gouv.fr/fr/datasets/plf-jaune-associations-subventionnees/)
+- [Projet de loi de finances pour 2021 (PLF 2021), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](/datasets/projet-de-loi-de-finances-pour-2021-plf-2021-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
+- [Projet de loi de finances pour 2020 (PLF 2020), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
+- [Projet de loi de finances pour 2019 (PLF 2019), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](/datasets/projet-de-loi-de-finances-pour-2019-plf-2019-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
+- [Projet de loi de finances pour 2018 (PLF 2018), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](/datasets/projet-de-loi-de-finances-pour-2018-plf-2018-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations-1/)
+- [Projet de loi de finances pour 2017 (PLF 2017), jaune effort financier de l’État en faveur des associations](/datasets/projet-de-loi-de-finances-pour-2017-plf-2017-jaune-effort-financier-de-letat-en-faveur-des-associations/#_)
+- [Projet de loi de finances pour 2016 (PLF 2016), jaune effort financier de l’État en faveur des associations](/datasets/projet-de-loi-de-finances-pour-2016-plf-2016-jaune-effort-financier-de-letat-en-faveur-des-associations/)
+- [Projet de loi de finances pour 2015 (PLF 2015), jaune effort financier de l’État en faveur des associations](/datasets/projet-de-loi-de-finances-pour-2015-plf-2015-jaune-effort-financier-de-letat-en-faveur-des-associations/)
+- [PLF - Jaune - Associations subventionnées 2010 - 2012](/datasets/plf-jaune-associations-subventionnees/)
 
-#### Par le [Ministère de la Culture](https://www.data.gouv.fr/fr/organizations/ministere-de-la-culture-et-de-la-communication/)
+#### Par le [Ministère de la Culture](/organizations/ministere-de-la-culture-et-de-la-communication/)
 
-- [Données essentielles des conventions de subvention](https://www.data.gouv.fr/fr/datasets/donnees-essentielles-des-conventions-de-subvention-5/)
+- [Données essentielles des conventions de subvention](/datasets/donnees-essentielles-des-conventions-de-subvention-5/)
 
 #### Par les collectivités territoriales
 
 ##### Conseils départementaux
 
-- [Subventions aux associations versées par le Département de Loire-Atlantique](https://www.data.gouv.fr/fr/datasets/subventions-aux-associations-versees-par-le-departement-de-loire-atlantique-2/)
-- [Données essentielles de conventions de subvention 2018 par le Département de Mayenne](https://www.data.gouv.fr/fr/datasets/donnees-essentielles-de-conventions-de-subvention-2018/)
-- [Données essentielles de conventions de subvention 2019 par le Département de Mayenne](https://www.data.gouv.fr/fr/datasets/donnees-essentielles-de-conventions-de-subvention-2019/)
-- [Détail des subventions accordées par le Département de la Gironde 2013 - 2016](https://www.data.gouv.fr/fr/datasets/detail-des-subventions-accordees-par-le-departement-de-la-gironde/)
-- [Subventions versées par le Conseil Départemental des Côtes d'Armor aux associations de 2002 à 2015](https://www.data.gouv.fr/fr/datasets/subventions-versees-par-le-conseil-departemental-des-cotes-darmor-aux-associations-de-2002-a-2015/)
-- [Subventions versées par le Conseil Départemental des Côtes d'Armor aux associations depuis 2016 (Décret)](https://www.data.gouv.fr/fr/datasets/subventions-versees-par-le-conseil-departemental-des-cotes-darmor-aux-associations-depuis-2016-decret-1/)
-- [Subventions aux personnes morales à partir de 2004 par le Département de Saône-et-Loire](https://www.data.gouv.fr/fr/datasets/subventions-aux-personnes-morales-a-partir-de-2004/)
+- [Subventions aux associations versées par le Département de Loire-Atlantique](/datasets/subventions-aux-associations-versees-par-le-departement-de-loire-atlantique-2/)
+- [Données essentielles de conventions de subvention 2018 par le Département de Mayenne](/datasets/donnees-essentielles-de-conventions-de-subvention-2018/)
+- [Données essentielles de conventions de subvention 2019 par le Département de Mayenne](/datasets/donnees-essentielles-de-conventions-de-subvention-2019/)
+- [Détail des subventions accordées par le Département de la Gironde 2013 - 2016](/datasets/detail-des-subventions-accordees-par-le-departement-de-la-gironde/)
+- [Subventions versées par le Conseil Départemental des Côtes d'Armor aux associations de 2002 à 2015](/datasets/subventions-versees-par-le-conseil-departemental-des-cotes-darmor-aux-associations-de-2002-a-2015/)
+- [Subventions versées par le Conseil Départemental des Côtes d'Armor aux associations depuis 2016 (Décret)](/datasets/subventions-versees-par-le-conseil-departemental-des-cotes-darmor-aux-associations-depuis-2016-decret-1/)
+- [Subventions aux personnes morales à partir de 2004 par le Département de Saône-et-Loire](/datasets/subventions-aux-personnes-morales-a-partir-de-2004/)
 
 ##### Conseils régionaux
 
-- [Subventions versées en 2013 aux associations ou aux fondations par la région Ile-de-France](https://www.data.gouv.fr/fr/datasets/subventions-versees-en-2013-aux-associations-ou-aux-fondations/#_) 
+- [Subventions versées en 2013 aux associations ou aux fondations par la région Ile-de-France](/datasets/subventions-versees-en-2013-aux-associations-ou-aux-fondations/#_) 
 
 ##### Communes
 
-- [Liste des associations parisiennes](https://www.data.gouv.fr/fr/datasets/liste-des-associations-parisiennes-prs/)
-- [Subvention mairie Bois-le-Roi aux associations de loi 1901 année 2020](https://www.data.gouv.fr/fr/datasets/subvention-mairie-bois-le-roi-aux-associations-de-loi-1901-annee-2020/)
+- [Liste des associations parisiennes](/datasets/liste-des-associations-parisiennes-prs/)
+- [Subvention mairie Bois-le-Roi aux associations de loi 1901 année 2020](/datasets/subvention-mairie-bois-le-roi-aux-associations-de-loi-1901-annee-2020/)
 
 
 ### Le hackathon "A l'asso des données"
 
-Co-organisé par Etalab, Le Mouvement associatif, Latitudes et le Comite National de Liaison des Régies de Quartier, le hackathon "A l'asso des données" tenu en Nomvembre 2019 a permis d'exploiter une sélection de jeux de données relatifs aux associations pour répondre à plusieurs défis.
+Co-organisé par Etalab, Le Mouvement associatif, Latitudes et le Comite National de Liaison des Régies de Quartier, le hackathon "A l'asso des données" tenu en Novembre 2019 a permis d'exploiter une sélection de jeux de données relatifs aux associations pour répondre à plusieurs défis.
 
-[Voir la page du hackathon et les données associées sur data.gouv.fr](https://www.data.gouv.fr/fr/posts/les-jeux-de-donnees-des-associations/)
+[Voir la page du hackathon et les données associées sur data.gouv.fr](/posts/les-jeux-de-donnees-des-associations/)
 
 [Voir l'article consacré au hackathon sur le blog d'Etalab](https://www.etalab.gouv.fr/comment-nous-avons-aide-a-organiser-le-hackathon-a-lasso-des-donnees)

--- a/pages/donnees-cles-par-sujet.md
+++ b/pages/donnees-cles-par-sujet.md
@@ -14,9 +14,9 @@ datasets:
 ## Données clés par sujet
 
 Retrouvez ici une sélection de jeux de données clés regroupés par sujet :
-- [Les données de référence (Service public de la donnée)](https://www.data.gouv.fr/fr/reference)
-- [Les données relatives au COVID-19](https://www.data.gouv.fr/fr/pages/donnees-coronavirus)
-- [Les données des élections](https://www.data.gouv.fr/fr/pages/donnees-des-elections)
-- [Les données relatives aux associations et aux fondations](https://www.data.gouv.fr/fr/pages/donnees-associations-fondations)
-- [Les données relatives aux comptes publics](https://www.data.gouv.fr/fr/pages/donnees-comptes-publics)
-- [Les données ouvertes pour l’apprentissage automatique (Machine Learning)](https://www.data.gouv.fr/fr/pages/donnees-machine-learning)
+- [Les données de référence (Service public de la donnée)](/reference)
+- [Les données relatives au COVID-19](/pages/donnees-coronavirus)
+- [Les données des élections](/pages/donnees-des-elections)
+- [Les données relatives aux associations et aux fondations](/pages/donnees-associations-fondations)
+- [Les données relatives aux comptes publics](/pages/donnees-comptes-publics)
+- [Les données ouvertes pour l’apprentissage automatique (Machine Learning)](/pages/donnees-machine-learning)

--- a/pages/donnees-comptes-publics.md
+++ b/pages/donnees-comptes-publics.md
@@ -76,14 +76,14 @@ La balance comptable est un document comptable qui reprend tous les comptes d’
 La balance comptable reproduit l'état de l'exercice à partir du grand livre (recueil de l'ensemble des comptes d'une structure qui tient sa comptabilité en partie double) en regroupant tous les totaux sur les soldes créditeurs et débiteurs.
 
 Le Ministère de l'Economie et des Finances publie en open data les données des balances comptables de différentes structures administratives : 
-- [Données de comptabilité générale de l'État](https://www.data.gouv.fr/fr/datasets/donnees-de-comptabilite-generale-de-letat/)
-- [Balances comptables des régions depuis 2010](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-regions-depuis-2010/)
-- [Balances comptables des départements depuis 2010](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-departements-depuis-2010/) 
-- [Balances comptables des communes 2010 - 2017](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-communes/)
-- [Balances comptables des collectivités et des établissements publics locaux avec la présentation croisée nature-fonction 2019](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-collectivites-et-des-etablissements-publics-locaux-avec-la-presentation-croisee-nature-fonction-2019/)
-- [Balances comptables des groupements à fiscalité propre depuis 2010](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-groupements-a-fiscalite-propre-depuis-2010/)
-- [Balances comptables des établissements publics locaux depuis 2010](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-etablissements-publics-locaux-depuis-2010/)
-- [Balances comptables des syndicats depuis 2010](https://www.data.gouv.fr/fr/datasets/balances-comptables-des-syndicats-depuis-2010/)
+- [Données de comptabilité générale de l'État](/datasets/donnees-de-comptabilite-generale-de-letat/)
+- [Balances comptables des régions depuis 2010](/datasets/balances-comptables-des-regions-depuis-2010/)
+- [Balances comptables des départements depuis 2010](/datasets/balances-comptables-des-departements-depuis-2010/) 
+- [Balances comptables des communes 2010 - 2017](/datasets/balances-comptables-des-communes/)
+- [Balances comptables des collectivités et des établissements publics locaux avec la présentation croisée nature-fonction 2019](/datasets/balances-comptables-des-collectivites-et-des-etablissements-publics-locaux-avec-la-presentation-croisee-nature-fonction-2019/)
+- [Balances comptables des groupements à fiscalité propre depuis 2010](/datasets/balances-comptables-des-groupements-a-fiscalite-propre-depuis-2010/)
+- [Balances comptables des établissements publics locaux depuis 2010](/datasets/balances-comptables-des-etablissements-publics-locaux-depuis-2010/)
+- [Balances comptables des syndicats depuis 2010](/datasets/balances-comptables-des-syndicats-depuis-2010/)
 
 ## Les agrégats comptables 
 
@@ -91,8 +91,8 @@ Les agrégats comptables sont produits en complément des balances comptables.Ce
 
 Les agrégats publiés sont ceux des budgets principaux et des budgets annexes des collectivités locales et de leurs établissements publics locaux (groupements à fiscalité propre, syndicats, caisses des écoles, caisses communales d'action sociale etc.).
 
-- [Agrégats comptables des collectivités et des établissements publics locaux 2017](https://www.data.gouv.fr/fr/datasets/agregats-comptables-des-collectivites-et-des-etablissements-publics-locaux-2017/)
-- [Agrégats comptables des collectivités et des établissements publics locaux 2018](https://www.data.gouv.fr/fr/datasets/agregats-comptables-des-collectivites-et-des-etablissements-publics-locaux-2018/)
+- [Agrégats comptables des collectivités et des établissements publics locaux 2017](/datasets/agregats-comptables-des-collectivites-et-des-etablissements-publics-locaux-2017/)
+- [Agrégats comptables des collectivités et des établissements publics locaux 2018](/datasets/agregats-comptables-des-collectivites-et-des-etablissements-publics-locaux-2018/)
 
 ## Les comptes individuels  
 
@@ -105,40 +105,40 @@ Les comptes individuels permettent d’analyser :
 Le Ministère de l'Economie et des Finances met à disposition en open data les données des comptes individuelles des différentes structures administratives :
 
 - [Comptes individuels des communes (fichier global) à compter de 2000](Comptes individuels des communes (fichier global) à compter de 2000 )
-- [Comptes individuels des groupements à fiscalité propre (fichier global) à compter de 2007](https://www.data.gouv.fr/fr/datasets/comptes-individuels-des-groupements-a-fiscalite-propre-fichier-global-a-compter-de-2007/)
-- [Comptes individuels des départements et des collectivités territoriales uniques (fichier global) à compter de 2008](https://www.data.gouv.fr/fr/datasets/comptes-individuels-des-departements-et-des-collectivites-territoriales-uniques-fichier-global-a-compter-de-2008/)
-- [Comptes individuels des régions (fichier global) à compter de 2008](https://www.data.gouv.fr/fr/datasets/comptes-individuels-des-regions-fichier-global-a-compter-de-2008/)
-- [Comptes individuels des collectivités](https://www.data.gouv.fr/fr/datasets/comptes-individuels-des-collectivites/)
+- [Comptes individuels des groupements à fiscalité propre (fichier global) à compter de 2007](/datasets/comptes-individuels-des-groupements-a-fiscalite-propre-fichier-global-a-compter-de-2007/)
+- [Comptes individuels des départements et des collectivités territoriales uniques (fichier global) à compter de 2008](/datasets/comptes-individuels-des-departements-et-des-collectivites-territoriales-uniques-fichier-global-a-compter-de-2008/)
+- [Comptes individuels des régions (fichier global) à compter de 2008](/datasets/comptes-individuels-des-regions-fichier-global-a-compter-de-2008/)
+- [Comptes individuels des collectivités](/datasets/comptes-individuels-des-collectivites/)
 
 Pour plus d’informations, vous pouvez [télécharger la note méthodologique](https://www.impots.gouv.fr/cll/application/pdf/methodo_commune.pdf).
 
-Par ailleurs, l'[observatoire des finances et de la gestion publique locales](https://www.data.gouv.fr/fr/organizations/observatoire-des-finances-et-de-la-gestion-publique-locales/) (OFGL) utiliser les données publiées par le Ministère de l'Economie et des Finances afin de proposer des comptes consolidés  : 
+Par ailleurs, l'[observatoire des finances et de la gestion publique locales](/organizations/observatoire-des-finances-et-de-la-gestion-publique-locales/) (OFGL) utiliser les données publiées par le Ministère de l'Economie et des Finances afin de proposer des comptes consolidés  : 
 
-- [Comptes des régions 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-regions-2012-2019/)
-- [Comptes consolidés des groupements à fiscalité propre 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-groupements-a-fiscalite-propre-2012-2019/)
-- [Comptes consolidés des communes 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-communes-2012-2019/)
-- [Comptes des départements 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-departements-2012-2019/)
-- [Comptes des communes 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-communes-2012-2019/)
-- [Comptes des SDIS 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-sdis-2012-2019/)
-- [Comptes consolidés des régions 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-regions-2012-2019/)
-- [Comptes consolidés des départements 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-consolides-des-departements-2012-2019/)
-- [Comptes des groupements à fiscalité propre 2012-2019](https://www.data.gouv.fr/fr/datasets/comptes-des-groupements-a-fiscalite-propre-2012-2019/)
+- [Comptes des régions 2012-2019](/datasets/comptes-des-regions-2012-2019/)
+- [Comptes consolidés des groupements à fiscalité propre 2012-2019](/datasets/comptes-consolides-des-groupements-a-fiscalite-propre-2012-2019/)
+- [Comptes consolidés des communes 2012-2019](/datasets/comptes-consolides-des-communes-2012-2019/)
+- [Comptes des départements 2012-2019](/datasets/comptes-des-departements-2012-2019/)
+- [Comptes des communes 2012-2019](/datasets/comptes-des-communes-2012-2019/)
+- [Comptes des SDIS 2012-2019](/datasets/comptes-des-sdis-2012-2019/)
+- [Comptes consolidés des régions 2012-2019](/datasets/comptes-consolides-des-regions-2012-2019/)
+- [Comptes consolidés des départements 2012-2019](/datasets/comptes-consolides-des-departements-2012-2019/)
+- [Comptes des groupements à fiscalité propre 2012-2019](/datasets/comptes-des-groupements-a-fiscalite-propre-2012-2019/)
 
 ## Les critères de répartition des dotations 
 
 La péréquation est un mécanisme de redistribution qui vise à réduire les écarts de richesse et les inégalités. Dans le secteur public, il s'agit un système de redistribution des ressources financières entre plusieurs personnes publiques. 
 
-La [Direction générale des collectivités locales (DGCL)](https://www.data.gouv.fr/fr/organizations/observatoire-des-finances-et-de-la-gestion-publique-locale/) publie en open data les principaux critères physiques et financiers utilisés pour la répartition des fonds nationaux de péréquation et pour la répartition des dotations de l’État aux collectivités territoriales. 
+La [Direction générale des collectivités locales (DGCL)](/organizations/observatoire-des-finances-et-de-la-gestion-publique-locale/) publie en open data les principaux critères physiques et financiers utilisés pour la répartition des fonds nationaux de péréquation et pour la répartition des dotations de l’État aux collectivités territoriales. 
 
-- [Critères de répartition des dotations versées par l’Etat aux collectivités territoriales ](https://www.data.gouv.fr/fr/datasets/criteres-de-repartition-des-dotations-versees-par-letat-aux-collectivites-territoriales/)
+- [Critères de répartition des dotations versées par l’Etat aux collectivités territoriales ](/datasets/criteres-de-repartition-des-dotations-versees-par-letat-aux-collectivites-territoriales/)
 
 ## Le fonctionnement des intercommunalités
 
 L'expression "intercommunalité" désigne les différentes formes de coopérations existantes entre les communes.
 
 La DGCL met à disposition des donneés qui contient de nombreuses informations sur les intercommunalités :
-- [Les données relatives à la liste, les coordonnées et le périmètre des groupements](https://www.data.gouv.fr/fr/datasets/base-nationale-sur-les-intercommunalites/)
-- [Les données relatives aux ressources financières et fiscales et à la situation socio-démographique des intercommunalités et autres structures territoriales](https://www.data.gouv.fr/fr/datasets/les-donnees-contextuelles-des-intercommunalites-et-autres-structures-territoriales/)
+- [Les données relatives à la liste, les coordonnées et le périmètre des groupements](/datasets/base-nationale-sur-les-intercommunalites/)
+- [Les données relatives aux ressources financières et fiscales et à la situation socio-démographique des intercommunalités et autres structures territoriales](/datasets/les-donnees-contextuelles-des-intercommunalites-et-autres-structures-territoriales/)
 
 
 ## Le fichier de recensement des élements d'imposition à la fiscalité locale (REI)
@@ -147,9 +147,9 @@ Le fichier de recensement des éléments d’imposition à la fiscalité directe
 
 Ces données concernent exclusivement les impositions primitives, c’est-à-dire qu’elles ne tiennent pas compte des impositions supplémentaires consécutives à des omissions ou insuffisances de l'imposition initiale.
 
-- [Impôts locaux : fichier de recensement des éléments d'imposition à la fiscalité directe locale (REI](https://www.data.gouv.fr/fr/datasets/impots-locaux-fichier-de-recensement-des-elements-dimposition-a-la-fiscalite-directe-locale-rei-3/) 
+- [Impôts locaux : fichier de recensement des éléments d'imposition à la fiscalité directe locale (REI](/datasets/impots-locaux-fichier-de-recensement-des-elements-dimposition-a-la-fiscalite-directe-locale-rei-3/) 
 
-Pour en savoir plus vous pouvez consultez les notices explicatives du REI [ici](https://www.data.gouv.fr/fr/datasets/r/b000742c-e4d0-46f1-b983-c940f9862057) et [ici](https://www.impots.gouv.fr/portail/files/media/stats/notice_explicative_rei_2018.pdf). Vous pouvez trouver la liste des variables et leur signification dans le tracé du fichier [ici](https://www.impots.gouv.fr/portail/files/media/stats/trace_rei_complet_2018.xlsx).
+Pour en savoir plus vous pouvez consultez les notices explicatives du REI [ici](/datasets/r/b000742c-e4d0-46f1-b983-c940f9862057) et [ici](https://www.impots.gouv.fr/portail/files/media/stats/notice_explicative_rei_2018.pdf). Vous pouvez trouver la liste des variables et leur signification dans le tracé du fichier [ici](https://www.impots.gouv.fr/portail/files/media/stats/trace_rei_complet_2018.xlsx).
 
 ## La commande publique 
 
@@ -157,51 +157,51 @@ Les acheteurs publics sont tenus de publier les données essentielles de leurs m
 
 Les acheteurs publics disposent de plusieurs modes de publication. Afin d'apporter une vision complète des données essentielles de la commande publique, Etalab publie une consolidation des données publiées sur différentes plateformes : 
 
-- [Fichiers consolidés des données essentielles de la commande publique (DECP)](https://www.data.gouv.fr/fr/datasets/fichiers-consolides-des-donnees-essentielles-de-la-commande-publique/) 
+- [Fichiers consolidés des données essentielles de la commande publique (DECP)](/datasets/fichiers-consolides-des-donnees-essentielles-de-la-commande-publique/) 
 
 Il est également possible de consulter les données publiées via le PES Marché : 
 
-- [Données essentielles de la commande publique transmises via le PES Marché](https://www.data.gouv.fr/fr/datasets/donnees-essentielles-de-la-commande-publique-transmises-via-le-pes-marche/)
+- [Données essentielles de la commande publique transmises via le PES Marché](/datasets/donnees-essentielles-de-la-commande-publique-transmises-via-le-pes-marche/)
 
 ## Le projet de loi Finance (PLF)
 
 Le projet de loi de finances est un document unique qui rassemble l’ensemble des recettes et des dépenses de l’État pour l’année à venir. Il propose le montant, la nature et l’affectation des ressources et des charges de l’État selon un équilibre économique et financier déterminé.  
  
-Le [ministère de l'Economie et des Finances](https://www.data.gouv.fr/fr/organizations/ministere-de-leconomie-et-des-finances/) met disposition les données sous-jacentes au projet de loi de finances et de ses annexes :
+Le [ministère de l'Economie et des Finances](/organizations/ministere-de-leconomie-et-des-finances/) met disposition les données sous-jacentes au projet de loi de finances et de ses annexes :
 
-- [Projet de loi de finances pour 2020 (PLF 2020), données du PLF et des annexes projet annuel de performance (PAP)](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-du-plf-et-des-annexes-projet-annuel-de-performance-pap/)
-- [Projet de loi de finances pour 2020 (PLF 2020), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
+- [Projet de loi de finances pour 2020 (PLF 2020), données du PLF et des annexes projet annuel de performance (PAP)](/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-du-plf-et-des-annexes-projet-annuel-de-performance-pap/)
+- [Projet de loi de finances pour 2020 (PLF 2020), données de l'annexe Jaune « Effort financier de l’État en faveur des associations »](/datasets/projet-de-loi-de-finances-pour-2020-plf-2020-donnees-de-lannexe-jaune-effort-financier-de-letat-en-faveur-des-associations/)
 
 Par la suite, l'Assemblée Nationale publie les amendements déposés sur le projet de loi proposé : 
 
-- [Amendements déposés à l'Assemblée nationale liés aux PLF et PLFSS 2018, 2019, 2020](https://www.data.gouv.fr/fr/datasets/amendements-deposes-a-lassemblee-nationale-lies-aux-plf-et-plfss-2018-2019-2020/)
+- [Amendements déposés à l'Assemblée nationale liés aux PLF et PLFSS 2018, 2019, 2020](/datasets/amendements-deposes-a-lassemblee-nationale-lies-aux-plf-et-plfss-2018-2019-2020/)
 
 Enfin, le Sénat publie en open data : 
 
-- [Projets de loi de finances - Rédaction de 1ère lecture au Sénat résultant des travaux de l’Assemblée nationale](https://www.data.gouv.fr/fr/datasets/projets-de-loi-de-finances-redaction-de-1ere-lecture-au-senat-resultant-des-travaux-de-lassemblee-nationale/)
-- [Amendements déposés au Sénat](https://www.data.gouv.fr/fr/datasets/amendements-deposes-au-senat/)
+- [Projets de loi de finances - Rédaction de 1ère lecture au Sénat résultant des travaux de l’Assemblée nationale](/datasets/projets-de-loi-de-finances-redaction-de-1ere-lecture-au-senat-resultant-des-travaux-de-lassemblee-nationale/)
+- [Amendements déposés au Sénat](/datasets/amendements-deposes-au-senat/)
 
 ## Les rapports relatifs aux comptes publics 
 
-La [Cour des comptes](https://www.data.gouv.fr/fr/organizations/cour-des-comptes/) publie différents rapports relatifs aux comptes publics : 
+La [Cour des comptes](/organizations/cour-des-comptes/) publie différents rapports relatifs aux comptes publics : 
 
 - Budget de l'État 
-  - [Exercice 2012](https://www.data.gouv.fr/fr/datasets/budget-de-letat-exercice-2012/)
-  - [Exercice 2013](https://www.data.gouv.fr/fr/datasets/budget-de-letat-exercice-2013-1/)
-  - [Exercice 2014](https://www.data.gouv.fr/fr/datasets/budget-de-letat-exercice-2014/)
-  - [Exercice 2015 (résultats et gestion)](https://www.data.gouv.fr/fr/datasets/budget-de-letat-exercice-2015-resultats-et-gestion/)
-  - [Exercice 2016 (résultats et gestion)](https://www.data.gouv.fr/fr/datasets/le-budget-de-letat-en-2016-resultats-et-gestion/)
-  - [Exercice 2017 (résultats et gestion)](https://www.data.gouv.fr/fr/datasets/le-budget-de-letat-en-2017-resultats-et-gestion/)
-  - [Exercice 2018 (résultats et gestion)](https://www.data.gouv.fr/fr/datasets/le-budget-de-letat-en-2018-resultats-et-gestion-1/)
-  - [Exercice 2019 (résultats et gestion)](https://www.data.gouv.fr/fr/datasets/le-budget-de-letat-en-2019-resultats-et-gestion/)
-- [Compte général de l’État (2006-2014)](https://www.data.gouv.fr/fr/datasets/compte-general-de-letat-2006-2014/)
+  - [Exercice 2012](/datasets/budget-de-letat-exercice-2012/)
+  - [Exercice 2013](/datasets/budget-de-letat-exercice-2013-1/)
+  - [Exercice 2014](/datasets/budget-de-letat-exercice-2014/)
+  - [Exercice 2015 (résultats et gestion)](/datasets/budget-de-letat-exercice-2015-resultats-et-gestion/)
+  - [Exercice 2016 (résultats et gestion)](/datasets/le-budget-de-letat-en-2016-resultats-et-gestion/)
+  - [Exercice 2017 (résultats et gestion)](/datasets/le-budget-de-letat-en-2017-resultats-et-gestion/)
+  - [Exercice 2018 (résultats et gestion)](/datasets/le-budget-de-letat-en-2018-resultats-et-gestion-1/)
+  - [Exercice 2019 (résultats et gestion)](/datasets/le-budget-de-letat-en-2019-resultats-et-gestion/)
+- [Compte général de l’État (2006-2014)](/datasets/compte-general-de-letat-2006-2014/)
 - Certification des comptes de l'État
-  - [Exercice 2015](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-de-letat-pour-lexercice-2015/)
-  - [Exercice 2016](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-de-letat-pour-lexercice-2016/)
-  - [Exercice 2017](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-2017-de-letat/)
-  - [Exercice 2019](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-2019-de-letat/)
+  - [Exercice 2015](/datasets/certification-des-comptes-de-letat-pour-lexercice-2015/)
+  - [Exercice 2016](/datasets/certification-des-comptes-de-letat-pour-lexercice-2016/)
+  - [Exercice 2017](/datasets/certification-des-comptes-2017-de-letat/)
+  - [Exercice 2019](/datasets/certification-des-comptes-2019-de-letat/)
 - Certification des comptes du régime général de sécurité sociale
-  - [Exercice 2015](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-du-regime-general-de-securite-sociale-2015-1/)
-  - [Exercice 2016](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-du-regime-general-de-securite-sociale-exercice-2016/)
-  - [Exercice 2017](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-2017-du-regime-general-de-securite-sociale/)
-  - [Exercice 2019](https://www.data.gouv.fr/fr/datasets/certification-des-comptes-2019-du-regime-general-de-securite-sociale/)
+  - [Exercice 2015](/datasets/certification-des-comptes-du-regime-general-de-securite-sociale-2015-1/)
+  - [Exercice 2016](/datasets/certification-des-comptes-du-regime-general-de-securite-sociale-exercice-2016/)
+  - [Exercice 2017](/datasets/certification-des-comptes-2017-du-regime-general-de-securite-sociale/)
+  - [Exercice 2019](/datasets/certification-des-comptes-2019-du-regime-general-de-securite-sociale/)

--- a/pages/donnees-coronavirus.md
+++ b/pages/donnees-coronavirus.md
@@ -91,121 +91,121 @@ datasets:
 
 **Données hospitalières**
 
-- [Données hospitalières relatives à l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/)
-- [Données des urgences hospitalières et de SOS Médecins relatives à l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-des-urgences-hospitalieres-et-de-sos-medecins-relatives-a-lepidemie-de-covid-19/)
+- [Données hospitalières relatives à l'épidémie de COVID-19](/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/)
+- [Données des urgences hospitalières et de SOS Médecins relatives à l'épidémie de COVID-19](/datasets/donnees-des-urgences-hospitalieres-et-de-sos-medecins-relatives-a-lepidemie-de-covid-19/)
 
 **Données relatives aux tests**
 
-- [Capacité analytique de tests virologiques dans le cadre de l'épidémie de COVID-19 (SI-DEP)](https://www.data.gouv.fr/fr/datasets/capacite-analytique-de-tests-virologiques-dans-le-cadre-de-lepidemie-covid-19/)
-- [Données relatives aux résultats des tests virologiques COVID-19 (SI-DEP)](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-resultats-des-tests-virologiques-covid-19/)
-- [Taux d'incidence de l'épidémie de COVID-19 (SI-DEP)](https://www.data.gouv.fr/fr/datasets/taux-dincidence-de-lepidemie-de-covid-19/)
-- [Taux d'incidence de l'épidémie de COVID-19 par métropole (SI-DEP)](https://www.data.gouv.fr/fr/datasets/indicateurs-de-lactivite-epidemique-taux-dincidence-de-lepidemie-de-covid-19-par-metropole/)
-- [Données de laboratoires infra-départementales durant l'épidémie COVID-19 (SI-DEP)](https://www.data.gouv.fr/fr/datasets/donnees-de-laboratoires-infra-departementales-durant-lepidemie-covid-19/)
-- [Données de laboratoires pour le dépistage, focus par niveau scolaire (SI-DEP)](https://www.data.gouv.fr/fr/datasets/donnees-de-laboratoires-pour-le-depistage-focus-par-niveau-scolaire/)
-- [Données de laboratoires pour le dépistage : Indicateurs sur les variants (SI-DEP)](https://www.data.gouv.fr/fr/datasets/donnees-de-laboratoires-pour-le-depistage-indicateurs-sur-les-variants/)
-- [Sites de prélèvements pour les tests COVID](https://www.data.gouv.fr/fr/datasets/sites-de-prelevements-pour-les-tests-covid/)
+- [Capacité analytique de tests virologiques dans le cadre de l'épidémie de COVID-19 (SI-DEP)](/datasets/capacite-analytique-de-tests-virologiques-dans-le-cadre-de-lepidemie-covid-19/)
+- [Données relatives aux résultats des tests virologiques COVID-19 (SI-DEP)](/datasets/donnees-relatives-aux-resultats-des-tests-virologiques-covid-19/)
+- [Taux d'incidence de l'épidémie de COVID-19 (SI-DEP)](/datasets/taux-dincidence-de-lepidemie-de-covid-19/)
+- [Taux d'incidence de l'épidémie de COVID-19 par métropole (SI-DEP)](/datasets/indicateurs-de-lactivite-epidemique-taux-dincidence-de-lepidemie-de-covid-19-par-metropole/)
+- [Données de laboratoires infra-départementales durant l'épidémie COVID-19 (SI-DEP)](/datasets/donnees-de-laboratoires-infra-departementales-durant-lepidemie-covid-19/)
+- [Données de laboratoires pour le dépistage, focus par niveau scolaire (SI-DEP)](/datasets/donnees-de-laboratoires-pour-le-depistage-focus-par-niveau-scolaire/)
+- [Données de laboratoires pour le dépistage : Indicateurs sur les variants (SI-DEP)](/datasets/donnees-de-laboratoires-pour-le-depistage-indicateurs-sur-les-variants/)
+- [Sites de prélèvements pour les tests COVID](/datasets/sites-de-prelevements-pour-les-tests-covid/)
 
 **Données relatives aux décès**
 
-- [Fichier des personnes décédées](https://www.data.gouv.fr/fr/datasets/fichier-des-personnes-decedees/)
+- [Fichier des personnes décédées](/datasets/fichier-des-personnes-decedees/)
 
 **Indicateurs de suivi de l'épidémie** 
 
-- [Indicateurs de suivi de l’épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/indicateurs-de-suivi-de-lepidemie-de-covid-19/)
+- [Indicateurs de suivi de l’épidémie de COVID-19](/datasets/indicateurs-de-suivi-de-lepidemie-de-covid-19/)
 
-[**Vue d'ensemble des données relatives à l'épidemie**](https://www.data.gouv.fr/fr/datasets/synthese-des-indicateurs-de-suivi-de-lepidemie-covid-19/)
+[**Vue d'ensemble des données relatives à l'épidemie**](/datasets/synthese-des-indicateurs-de-suivi-de-lepidemie-covid-19/)
 
-[Ancien jeu de données de vue d'ensemble](https://www.data.gouv.fr/fr/datasets/donnees-relatives-a-lepidemie-de-covid-19-en-france-vue-densemble/)
+[Ancien jeu de données de vue d'ensemble](/datasets/donnees-relatives-a-lepidemie-de-covid-19-en-france-vue-densemble/)
 
 Les jeux des données suivants ont été mis à disposition durant la première vague de l'épidémie. À noter qu'ils n'ont pas été mis à jour récemment :
 
-- [Données de certification électronique des décès associés au COVID-19 (CEPIDC)](https://www.data.gouv.fr/fr/datasets/donnees-de-certification-electronique-des-deces-associes-au-covid-19-cepidc/)
-- [Niveaux d'excès de mortalité standardisé durant l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/niveaux-dexces-de-mortalite-standardise-durant-lepidemie-de-covid-19/)
-- [Nombre de décès quotidiens par département](https://www.data.gouv.fr/fr/datasets/nombre-de-deces-quotidiens-par-departement/)
-- [Part des patients COVID-19 dans les réanimations](https://www.data.gouv.fr/fr/datasets/indicateurs-de-lactivite-epidemique-part-des-patients-covid-19-dans-les-reanimations/)
-- [Transferts de patients atteints de COVID-19](https://www.data.gouv.fr/fr/datasets/transferts-de-patients-atteints-de-covid-19/)
-- [Nombre de décès quotidiens par département](https://www.data.gouv.fr/fr/datasets/nombre-de-deces-quotidiens-par-departement/)
-- [Données de la carte de vigilance COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-de-la-carte-de-vigilance-covid-19/)
+- [Données de certification électronique des décès associés au COVID-19 (CEPIDC)](/datasets/donnees-de-certification-electronique-des-deces-associes-au-covid-19-cepidc/)
+- [Niveaux d'excès de mortalité standardisé durant l'épidémie de COVID-19](/datasets/niveaux-dexces-de-mortalite-standardise-durant-lepidemie-de-covid-19/)
+- [Nombre de décès quotidiens par département](/datasets/nombre-de-deces-quotidiens-par-departement/)
+- [Part des patients COVID-19 dans les réanimations](/datasets/indicateurs-de-lactivite-epidemique-part-des-patients-covid-19-dans-les-reanimations/)
+- [Transferts de patients atteints de COVID-19](/datasets/transferts-de-patients-atteints-de-covid-19/)
+- [Nombre de décès quotidiens par département](/datasets/nombre-de-deces-quotidiens-par-departement/)
+- [Données de la carte de vigilance COVID-19](/datasets/donnees-de-la-carte-de-vigilance-covid-19/)
 
 ## Données relatives aux vaccins
 
-- [Données relatives aux personnes vaccinées contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-personnes-vaccinees-contre-la-covid-19-1/)
-- [Données relatives aux personnes présentant des comorbidités vaccinées contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-personnes-presentant-des-comorbidites-vaccinees-contre-la-covid-19/)
-- [Données relatives aux personnes très vulnérables vaccinées contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-personnes-tres-vulnerables-vaccinees-contre-la-covid-19/)
-- [Lieux de vaccination contre la Covid-19](https://www.data.gouv.fr/fr/datasets/lieux-de-vaccination-contre-la-covid-19/)
-- [Lieux de vaccination Covid-19 (pharmacies) - Santé.fr](https://www.data.gouv.fr/fr/datasets/lieux-de-vaccination-covid-19-pharmacies-sante-fr/)
-- [Données vaccination par lieu de vaccination](https://www.data.gouv.fr/fr/datasets/donnees-vaccination-par-lieu-de-vaccination/)
-- [Données vaccination par catégorie d'injecteur, hors centres de vaccination et établissements de santé](https://www.data.gouv.fr/fr/datasets/donnees-vaccination-par-categorie-dinjecteur-hors-centres-de-vaccination-et-etablissements-de-sante/)
-- [Données vaccination par tranche d'âge, type de vaccin et département](https://www.data.gouv.fr/fr/datasets/donnees-vaccination-par-tranche-dage-type-de-vaccin-et-departement/)
-- [Données vaccination par pathologie et département](https://www.data.gouv.fr/fr/datasets/donnees-vaccination-par-pathologie-et-departement/)
-- [Données relatives aux stocks des doses de vaccins contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-stocks-des-doses-de-vaccins-contre-la-covid-19/)
-- [Données relatives aux livraisons de vaccins contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-livraisons-de-vaccins-contre-la-covid-19/)
-- [Données des rendez-vous pris dans des centres de vaccination contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-des-rendez-vous-pris-dans-des-centres-de-vaccination-contre-la-covid-19/)
+- [Données relatives aux personnes vaccinées contre la COVID-19](/datasets/donnees-relatives-aux-personnes-vaccinees-contre-la-covid-19-1/)
+- [Données relatives aux personnes présentant des comorbidités vaccinées contre la COVID-19](/datasets/donnees-relatives-aux-personnes-presentant-des-comorbidites-vaccinees-contre-la-covid-19/)
+- [Données relatives aux personnes très vulnérables vaccinées contre la COVID-19](/datasets/donnees-relatives-aux-personnes-tres-vulnerables-vaccinees-contre-la-covid-19/)
+- [Lieux de vaccination contre la Covid-19](/datasets/lieux-de-vaccination-contre-la-covid-19/)
+- [Lieux de vaccination Covid-19 (pharmacies) - Santé.fr](/datasets/lieux-de-vaccination-covid-19-pharmacies-sante-fr/)
+- [Données vaccination par lieu de vaccination](/datasets/donnees-vaccination-par-lieu-de-vaccination/)
+- [Données vaccination par catégorie d'injecteur, hors centres de vaccination et établissements de santé](/datasets/donnees-vaccination-par-categorie-dinjecteur-hors-centres-de-vaccination-et-etablissements-de-sante/)
+- [Données vaccination par tranche d'âge, type de vaccin et département](/datasets/donnees-vaccination-par-tranche-dage-type-de-vaccin-et-departement/)
+- [Données vaccination par pathologie et département](/datasets/donnees-vaccination-par-pathologie-et-departement/)
+- [Données relatives aux stocks des doses de vaccins contre la COVID-19](/datasets/donnees-relatives-aux-stocks-des-doses-de-vaccins-contre-la-covid-19/)
+- [Données relatives aux livraisons de vaccins contre la COVID-19](/datasets/donnees-relatives-aux-livraisons-de-vaccins-contre-la-covid-19/)
+- [Données des rendez-vous pris dans des centres de vaccination contre la COVID-19](/datasets/donnees-des-rendez-vous-pris-dans-des-centres-de-vaccination-contre-la-covid-19/)
 
 ## Données économiques
 
 Afin de soutenir les entreprises directement impactées par la crise Covid-19, l'Etat a mis en place plusieurs dispositifs d'aides. Retrouvrez ci-dessous les données relatives aux aides versées par l'Etat aux entreprises : 
 
-- [Données relatives au dispositif d'activité partielle mis en oeuvre dans le cadre de l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-au-dispositif-dactivite-partielle-mis-en-oeuvre-dans-le-cadre-de-lepidemie-de-covid-19/)
-- [Données relatives au fonds de solidarité mis en place dans le cadre de l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-au-fonds-de-solidarite-mis-en-place-dans-le-cadre-de-lepidemie-de-covid-19/)
-- [Données relatives aux prêts garantis par l’Etat dans le cadre de l’épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-prets-garantis-par-letat-dans-le-cadre-de-lepidemie-de-covid-19/)
-- [Données relatives aux reports d'échéances fiscales accordés dans le cadre de l’épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-reports-decheances-fiscales-accordes-dans-le-cadre-de-lepidemie-de-covid-19/)
-- [Aide exceptionnelle « CPSTI RCI COVID-19 »](https://www.data.gouv.fr/fr/datasets/aide-exceptionnelle-cpsti-rci-covid-19/)
-- [Données relatives aux aides exceptionnelles aux artisans et commerçants dans le cadre de l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-aides-exceptionnelles-aux-artisans-et-commercants-dans-le-cadre-de-lepidemie-de-covid-19/)
-- [Les dispositifs de l'État en faveur des salariés des entreprises en difficulté](https://www.data.gouv.fr/fr/datasets/les-dispositifs-de-letat-en-faveur-des-salaries-des-entreprises-en-difficulte/)
+- [Données relatives au dispositif d'activité partielle mis en oeuvre dans le cadre de l'épidémie de COVID-19](/datasets/donnees-relatives-au-dispositif-dactivite-partielle-mis-en-oeuvre-dans-le-cadre-de-lepidemie-de-covid-19/)
+- [Données relatives au fonds de solidarité mis en place dans le cadre de l'épidémie de COVID-19](/datasets/donnees-relatives-au-fonds-de-solidarite-mis-en-place-dans-le-cadre-de-lepidemie-de-covid-19/)
+- [Données relatives aux prêts garantis par l’Etat dans le cadre de l’épidémie de COVID-19](/datasets/donnees-relatives-aux-prets-garantis-par-letat-dans-le-cadre-de-lepidemie-de-covid-19/)
+- [Données relatives aux reports d'échéances fiscales accordés dans le cadre de l’épidémie de COVID-19](/datasets/donnees-relatives-aux-reports-decheances-fiscales-accordes-dans-le-cadre-de-lepidemie-de-covid-19/)
+- [Aide exceptionnelle « CPSTI RCI COVID-19 »](/datasets/aide-exceptionnelle-cpsti-rci-covid-19/)
+- [Données relatives aux aides exceptionnelles aux artisans et commerçants dans le cadre de l'épidémie de COVID-19](/datasets/donnees-relatives-aux-aides-exceptionnelles-aux-artisans-et-commercants-dans-le-cadre-de-lepidemie-de-covid-19/)
+- [Les dispositifs de l'État en faveur des salariés des entreprises en difficulté](/datasets/les-dispositifs-de-letat-en-faveur-des-salaries-des-entreprises-en-difficulte/)
 - Mesures exceptionnelles Covid-19 : reports de cotisations Urssaf (employeurs)
-  - [France entière x secteur NA88](https://www.data.gouv.fr/fr/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-employeurs-france-entiere-x-secteur-na88/)
-  - [Par département x grand secteur](https://www.data.gouv.fr/fr/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-employeurs-par-departement-x-grand-secteur/)
+  - [France entière x secteur NA88](/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-employeurs-france-entiere-x-secteur-na88/)
+  - [Par département x grand secteur](/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-employeurs-par-departement-x-grand-secteur/)
 - Mesures exceptionnelles Covid-19 : reports de cotisations Urssaf (TI)
-  - [France entière x secteur NA88](https://www.data.gouv.fr/fr/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-ti-france-entiere-x-secteur-na88/)
-  - [Par département x grand secteur](https://www.data.gouv.fr/fr/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-ti-par-departement-x-grand-secteur/)
+  - [France entière x secteur NA88](/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-ti-france-entiere-x-secteur-na88/)
+  - [Par département x grand secteur](/datasets/mesures-exceptionnelles-covid-19-reports-de-cotisations-urssaf-ti-par-departement-x-grand-secteur/)
 
 Il est également possible de consulter les données sur [le tableau de bord des aides aux entreprises](https://aides-entreprises.data.gouv.fr/).
 
 
 ## Données de la recherche
 
-- [Financements publics de projets de recherche en rapport avec la crise sanitaire du COVID-19](https://www.data.gouv.fr/fr/datasets/financements-publics-de-projets-de-recherche-en-rapport-avec-la-crise-sanitaire-du-covid-19/)
-- [Publications françaises #Covid19 référencées dans PubMed](https://www.data.gouv.fr/fr/datasets/publications-francaises-covid19-referencees-dans-pubmed/)
+- [Financements publics de projets de recherche en rapport avec la crise sanitaire du COVID-19](/datasets/financements-publics-de-projets-de-recherche-en-rapport-avec-la-crise-sanitaire-du-covid-19/)
+- [Publications françaises #Covid19 référencées dans PubMed](/datasets/publications-francaises-covid19-referencees-dans-pubmed/)
 
 ## Données d'information
 
-- [Métriques d'utilisation de l'application TousAntiCovid](https://www.data.gouv.fr/fr/datasets/metriques-dutilisation-de-lapplication-tousanticovid/)
-- [Inclusions hebdomadaires dans la plateforme de télémédecine Covidom](https://www.data.gouv.fr/fr/datasets/inclusions-hebdomadaires-dans-la-plateforme-de-telemedecine-covidom/)
-- [Description des alertes dans la plateforme de télémédecine Covidom](https://www.data.gouv.fr/fr/datasets/description-des-alertes-dans-la-plateforme-de-telemedecine-covidom/)
-- [Données issues du questionnaire d’orientation COVID-19 du Service d’information du Gouvernement (SIG)](https://www.data.gouv.fr/fr/datasets/donnees-issues-du-questionnaire-dorientation-covid-19-du-service-dinformation-du-gouvernement-sig/)
-- [Contenu textuel de la Foire Aux Questions « info entreprises COVID19 »](https://www.data.gouv.fr/fr/datasets/contenu-textuel-de-la-foire-aux-questions-info-entreprises-covid19/)
-- [Foires aux questions publiées par les administrations dans le cadre de la gestion de la pandémie Covid-19](https://www.data.gouv.fr/fr/datasets/foires-aux-questions-publiees-par-les-administrations-dans-le-cadre-de-la-gestion-de-la-pandemie-covid-19/)
-- [Liste des liens URL redirigeant vers les consignes préféctorales dans le cadre du Covid-19](https://www.data.gouv.fr/fr/datasets/liste-des-liens-url-redirigeant-vers-les-consignes-prefectorales-dans-le-cadre-du-covid-19/)
-- [Population présente sur le territoire avant et après le début du confinement – Premiers résultats](https://www.data.gouv.fr/fr/datasets/population-presente-sur-le-territoire-avant-et-apres-le-debut-du-confinement-premiers-resultats/)
+- [Métriques d'utilisation de l'application TousAntiCovid](/datasets/metriques-dutilisation-de-lapplication-tousanticovid/)
+- [Inclusions hebdomadaires dans la plateforme de télémédecine Covidom](/datasets/inclusions-hebdomadaires-dans-la-plateforme-de-telemedecine-covidom/)
+- [Description des alertes dans la plateforme de télémédecine Covidom](/datasets/description-des-alertes-dans-la-plateforme-de-telemedecine-covidom/)
+- [Données issues du questionnaire d’orientation COVID-19 du Service d’information du Gouvernement (SIG)](/datasets/donnees-issues-du-questionnaire-dorientation-covid-19-du-service-dinformation-du-gouvernement-sig/)
+- [Contenu textuel de la Foire Aux Questions « info entreprises COVID19 »](/datasets/contenu-textuel-de-la-foire-aux-questions-info-entreprises-covid19/)
+- [Foires aux questions publiées par les administrations dans le cadre de la gestion de la pandémie Covid-19](/datasets/foires-aux-questions-publiees-par-les-administrations-dans-le-cadre-de-la-gestion-de-la-pandemie-covid-19/)
+- [Liste des liens URL redirigeant vers les consignes préféctorales dans le cadre du Covid-19](/datasets/liste-des-liens-url-redirigeant-vers-les-consignes-prefectorales-dans-le-cadre-du-covid-19/)
+- [Population présente sur le territoire avant et après le début du confinement – Premiers résultats](/datasets/population-presente-sur-le-territoire-avant-et-apres-le-debut-du-confinement-premiers-resultats/)
 
 ## Données des territoires
 
 Plusieurs villes et collectivités locales ont publié des jeux de données relatifs au COVID-19. Voici quelques exemples :  
 
-- La Ville d'Antibes publie [les arrêtés de police réglementaires relatifs au COVID-19](https://www.data.gouv.fr/fr/datasets/covid-19-arretes-de-police-reglementaires-pris-par-le-maire-dantibes/)
-- La région Provence Alpes Côte d’Azur collecte [les données sur les initiatives des communautés de Makers COVID-19](https://www.data.gouv.fr/fr/datasets/covid-19-indicateurs-de-production-des-communautes-de-makers-en-provence-alpes-cote-dazur/)
+- La Ville d'Antibes publie [les arrêtés de police réglementaires relatifs au COVID-19](/datasets/covid-19-arretes-de-police-reglementaires-pris-par-le-maire-dantibes/)
+- La région Provence Alpes Côte d’Azur collecte [les données sur les initiatives des communautés de Makers COVID-19](/datasets/covid-19-indicateurs-de-production-des-communautes-de-makers-en-provence-alpes-cote-dazur/)
 
 **Mesures de politiques publiques territoriales**
 
-- [Musées ouverts pendant l'été 2020 en Île-de-France](https://www.data.gouv.fr/fr/datasets/musees-ouverts-pendant-lete-2020/)
-- Nantes Métropole a publié les données des  [aménagements cyclables temporaires](https://www.data.gouv.fr/fr/datasets/amenagements-cyclables-de-nantes-metropole-crise-sanitaire-covid-19/)
-- Délimitation géographique du port du masque obligatoire [à Grenoble](https://www.data.gouv.fr/fr/datasets/delimitation-geographique-du-port-du-masque-obligatoire/) et [à Nantes](https://www.data.gouv.fr/fr/datasets/zones-de-port-du-masque-obligatoire-de-la-ville-de-nantes-crise-sanitaire-covid-19/)
-- La Ville de Toulouse a mis à jour [la liste des autorisations d’occupation du domaine public, avec les extensions dues au Covid](https://www.data.gouv.fr/fr/datasets/terrasses-autorisees-ville-de-toulouse-1/)
-- [Lieux de distribution de masques à Marseille](https://www.data.gouv.fr/fr/datasets/marseille-lieux-de-distribution-de-masques/)
-- [Distributeurs de gel hydro-alcoolique à Orléans](https://www.data.gouv.fr/fr/datasets/distributeurs-de-gel-hydro-alcoolique-ville-dorleans/)
-- [Liste des sites de distribution des masques à Issy-les-Moulineaux](https://www.data.gouv.fr/fr/datasets/liste-des-sites-de-distribution-des-masques/). À noter que ce jeu de données n'est pas à jour. 
-- [Liste des sites de distribution des masques à Issy-les-Moulineaux](https://www.data.gouv.fr/fr/datasets/liste-des-sites-de-distribution-des-masques/). À noter que ce jeu de données n'est pas à jour. 
+- [Musées ouverts pendant l'été 2020 en Île-de-France](/datasets/musees-ouverts-pendant-lete-2020/)
+- Nantes Métropole a publié les données des  [aménagements cyclables temporaires](/datasets/amenagements-cyclables-de-nantes-metropole-crise-sanitaire-covid-19/)
+- Délimitation géographique du port du masque obligatoire [à Grenoble](/datasets/delimitation-geographique-du-port-du-masque-obligatoire/) et [à Nantes](/datasets/zones-de-port-du-masque-obligatoire-de-la-ville-de-nantes-crise-sanitaire-covid-19/)
+- La Ville de Toulouse a mis à jour [la liste des autorisations d’occupation du domaine public, avec les extensions dues au Covid](/datasets/terrasses-autorisees-ville-de-toulouse-1/)
+- [Lieux de distribution de masques à Marseille](/datasets/marseille-lieux-de-distribution-de-masques/)
+- [Distributeurs de gel hydro-alcoolique à Orléans](/datasets/distributeurs-de-gel-hydro-alcoolique-ville-dorleans/)
+- [Liste des sites de distribution des masques à Issy-les-Moulineaux](/datasets/liste-des-sites-de-distribution-des-masques/). À noter que ce jeu de données n'est pas à jour. 
+- [Liste des sites de distribution des masques à Issy-les-Moulineaux](/datasets/liste-des-sites-de-distribution-des-masques/). À noter que ce jeu de données n'est pas à jour. 
 
 **Données relatives au confinement**
 
-- [Commerces alimentaires ouverts à Saint-Nazaire pendant le confinement](https://www.data.gouv.fr/fr/datasets/covid19-commerces-alimentaires-ouverts-a-saint-nazaire/)
+- [Commerces alimentaires ouverts à Saint-Nazaire pendant le confinement](/datasets/covid19-commerces-alimentaires-ouverts-a-saint-nazaire/)
 - La Ville d'Issy-les-Moulineaux a publié les listes de:
-  - [Commerces alimentaires ouverts en période de confinement](https://www.data.gouv.fr/fr/datasets/les-commerces-alimentaires-isseens-ouverts-en-periode-de-confinement/)
-  - [Commerces des marchés qui livrent en temps de confinement](https://www.data.gouv.fr/fr/datasets/liste-des-commerces-des-marches-qui-livrent-en-temps-de-confinement/)
-  - [Commerces qui proposent une livraison à domicile en période de confinement](https://www.data.gouv.fr/fr/datasets/liste-des-commerces-isseens-qui-proposent-une-livraison-a-domicile-durant-le-covid-19/)
-- [Écoles de regroupement de Marseille ouvertes pendant le confinement](https://www.data.gouv.fr/fr/datasets/marseille-covid19-ecoles-de-regroupement/)
-- [Recensement Commerces, établissements et services ouverts pendant la période COVID-19 dans l'agglomération de Nevers](https://www.data.gouv.fr/fr/datasets/recensement-commerces-ets-et-services-ouverts-pendant-la-periode-covid-19/)
+  - [Commerces alimentaires ouverts en période de confinement](/datasets/les-commerces-alimentaires-isseens-ouverts-en-periode-de-confinement/)
+  - [Commerces des marchés qui livrent en temps de confinement](/datasets/liste-des-commerces-des-marches-qui-livrent-en-temps-de-confinement/)
+  - [Commerces qui proposent une livraison à domicile en période de confinement](/datasets/liste-des-commerces-isseens-qui-proposent-une-livraison-a-domicile-durant-le-covid-19/)
+- [Écoles de regroupement de Marseille ouvertes pendant le confinement](/datasets/marseille-covid19-ecoles-de-regroupement/)
+- [Recensement Commerces, établissements et services ouverts pendant la période COVID-19 dans l'agglomération de Nevers](/datasets/recensement-commerces-ets-et-services-ouverts-pendant-la-periode-covid-19/)
 
 ## Les réutilisations de données
 
@@ -225,15 +225,15 @@ En continuité de l'initiative « OpenCOVID19 », l’équipe d’Etalab a trava
 
 ## Liste des organisations qui publient des données relatives au Covid-19
 
-- [Santé publique France](https://www.data.gouv.fr/fr/organizations/sante-publique-france/)
-- [Ministère des Solidarités et de la Santé](https://www.data.gouv.fr/fr/organizations/ministere-des-solidarites-et-de-la-sante/)
-- [Etalab](https://www.data.gouv.fr/fr/organizations/etalab/)
-- [Institut National de la Statistique et des Etudes Economiques (Insee)](https://www.data.gouv.fr/fr/organizations/institut-national-de-la-statistique-et-des-etudes-economiques-insee/)
-- [Unions de Recouvrement des cotisations de Sécurité Sociale et d'Allocations Familiales (URSSAF)](https://www.data.gouv.fr/fr/organizations/unions-de-recouvrement-des-cotisations-de-securite-sociale-et-dallocations-familiales/)
-- [Cour des comptes](https://www.data.gouv.fr/fr/organizations/cour-des-comptes/)
-- [Ministère de l'Enseignement supérieur, de la Recherche et de l'Innovation](https://www.data.gouv.fr/fr/organizations/enseignement-superieur-et-recherche/)
-- [Service d'Information du Gouvernement](https://www.data.gouv.fr/fr/organizations/service-d-information-du-gouvernement/)
-- [Direction Générale des Entreprises](https://www.data.gouv.fr/fr/organizations/direction-generale-des-entreprises/)
+- [Santé publique France](/organizations/sante-publique-france/)
+- [Ministère des Solidarités et de la Santé](/organizations/ministere-des-solidarites-et-de-la-sante/)
+- [Etalab](/organizations/etalab/)
+- [Institut National de la Statistique et des Etudes Economiques (Insee)](/organizations/institut-national-de-la-statistique-et-des-etudes-economiques-insee/)
+- [Unions de Recouvrement des cotisations de Sécurité Sociale et d'Allocations Familiales (URSSAF)](/organizations/unions-de-recouvrement-des-cotisations-de-securite-sociale-et-dallocations-familiales/)
+- [Cour des comptes](/organizations/cour-des-comptes/)
+- [Ministère de l'Enseignement supérieur, de la Recherche et de l'Innovation](/organizations/enseignement-superieur-et-recherche/)
+- [Service d'Information du Gouvernement](/organizations/service-d-information-du-gouvernement/)
+- [Direction Générale des Entreprises](/organizations/direction-generale-des-entreprises/)
 
 ## Article de blog
 

--- a/pages/donnees-des-elections.md
+++ b/pages/donnees-des-elections.md
@@ -44,14 +44,14 @@ datasets:
 
 ## Élections Municipales
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 - **Élections municipales 2020** :
-  -  [Municipales 2020  - Résultats du second tour](https://www.data.gouv.fr/fr/datasets/municipales-2020-resultats-2nd-tour/)
-  -  [Liste des candidatures au second tour](https://www.data.gouv.fr/fr/datasets/elections-municipales-2020-candidatures-au-second-tour/)
-  -  [Liste des candidats élus au 1er tour et liste des communes entièrement pourvues](https://www.data.gouv.fr/fr/datasets/election-municipales-2020-liste-des-candidats-elus-au-t1-et-liste-des-communes-entierement-pourvues/)
-  -  [Candidatures au 1er tour](https://www.data.gouv.fr/fr/datasets/elections-municipales-2020-candidatures-au-1er-tour/)
-  -  [Résultats du 1er tour](https://www.data.gouv.fr/fr/datasets/elections-municipales-2020-resultats/)
+  -  [Municipales 2020  - Résultats du second tour](/datasets/municipales-2020-resultats-2nd-tour/)
+  -  [Liste des candidatures au second tour](/datasets/elections-municipales-2020-candidatures-au-second-tour/)
+  -  [Liste des candidats élus au 1er tour et liste des communes entièrement pourvues](/datasets/election-municipales-2020-liste-des-candidats-elus-au-t1-et-liste-des-communes-entierement-pourvues/)
+  -  [Candidatures au 1er tour](/datasets/elections-municipales-2020-candidatures-au-1er-tour/)
+  -  [Résultats du 1er tour](/datasets/elections-municipales-2020-resultats/)
 
 
 -   **Élections municipales partielles des 14 et 21 juin 2015** :
@@ -113,7 +113,7 @@ datasets:
 
 ## Élections Européennes
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 -   **Élections européennes 1994** :
     - Résultats 1e et 2nd tours: [par communes](http://static.data.gouv.fr/8e/086e01daf0bd7bc346d85f623f2c4a42e28a7f3909ae9cc45db464b76b0626.xls)
@@ -142,20 +142,20 @@ datasets:
     - Résultats 1e et 2nd tours: par circonscriptions européennes, régions, départements, circonscriptions législatives, cantons et liste des élus [provisoires](https://www.data.gouv.fr/storage/f/2014-05-26T14-49-22/euro-2014-resultats.xlsx) et [validés](https://www.data.gouv.fr/storage/f/2014-05-30T10-34-25/euro-2014-resultats-c.xlsx)
 
 - **Élections européennes 2019** :
-    -   [Listes des candidats](https://www.data.gouv.fr/fr/datasets/elections-europeennes-du-26-mai-2019-les-candidatures-enregistrees/).
-    -   [Résultats des élections européennes 2019](https://www.data.gouv.fr/fr/datasets/resultats-des-elections-europeennes-2019/).
+    -   [Listes des candidats](/datasets/elections-europeennes-du-26-mai-2019-les-candidatures-enregistrees/).
+    -   [Résultats des élections européennes 2019](/datasets/resultats-des-elections-europeennes-2019/).
 
 ## Élections législatives
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 - **Élections législatives des 11 et 18 juin 2017** :
-    - [Liste des candidats](https://www.data.gouv.fr/fr/datasets/elections-legislatives-des-11-et-18-juin-2017-liste-des-candidats-du-1er-tour/)
-    - Résultats 1er tour : [par bureaux de vote](https://www.data.gouv.fr/fr/datasets/r/80cb1309-9147-4bae-b6e2-79877d549b50)
-    - Résultats 1er tour : [par communes](https://www.data.gouv.fr/fr/datasets/r/7b613086-b5f5-4745-82e8-11b7397f9334)
-    - Résultats 1er tour : [par régions, départements, circonscriptions législatives, cantons et liste des élus à l’issue de l’élection](https://www.data.gouv.fr/fr/datasets/r/3eb503cd-49cf-4e04-9efd-7262580f7fc7)
-    - Résultats 2e tour : [par bureaux de vote](https://www.data.gouv.fr/fr/datasets/5948d371c751df471327bc4a)
-    - Résultats 2e tour : [par communes](https://www.data.gouv.fr/fr/datasets/elections-legislatives-des-11-et-18-juin-2017-resultats-du-2nd-tour-par-communes/)
-    - Résultats 2e tour : [par régions, départements, circonscriptions législatives, cantons et liste des élus à l’issue de l’élection](https://www.data.gouv.fr/fr/datasets/elections-legislatives-des-11-et-18-juin-2017-resultats-du-2nd-tour/)
+    - [Liste des candidats](/datasets/elections-legislatives-des-11-et-18-juin-2017-liste-des-candidats-du-1er-tour/)
+    - Résultats 1er tour : [par bureaux de vote](/datasets/r/80cb1309-9147-4bae-b6e2-79877d549b50)
+    - Résultats 1er tour : [par communes](/datasets/r/7b613086-b5f5-4745-82e8-11b7397f9334)
+    - Résultats 1er tour : [par régions, départements, circonscriptions législatives, cantons et liste des élus à l’issue de l’élection](/datasets/r/3eb503cd-49cf-4e04-9efd-7262580f7fc7)
+    - Résultats 2e tour : [par bureaux de vote](/datasets/5948d371c751df471327bc4a)
+    - Résultats 2e tour : [par communes](/datasets/elections-legislatives-des-11-et-18-juin-2017-resultats-du-2nd-tour-par-communes/)
+    - Résultats 2e tour : [par régions, départements, circonscriptions législatives, cantons et liste des élus à l’issue de l’élection](/datasets/elections-legislatives-des-11-et-18-juin-2017-resultats-du-2nd-tour/)
 
 
 - **Élections législatives partielles 2016** :
@@ -193,7 +193,7 @@ datasets:
     - Résultats 1er et 2nd tours : [par communes](http://static.data.gouv.fr/fe/23cb194d0e91dc35947f0fe5eee79d42c144079b0aa93ad7b465335354c040.xls)
     - Résultats 1er et 2nd tours : [par régions, départements, circonscriptions législatives, cantons et liste des élus à l’issue de l’élection](http://static.data.gouv.fr/4d/31c587f56b293e3b48c7ba2951fdbe09c4f5396317e0793a5e3ac33b396e22.xls)
 
-### Données du Centre de données socio-politiques de [Sciences Po](https://www.data.gouv.fr/fr/organizations/sciences-po/)
+### Données du Centre de données socio-politiques de [Sciences Po](/organizations/sciences-po/)
 
 
 - **Élections Législatives 1958** :
@@ -302,7 +302,7 @@ datasets:
 
 ## Élections présidentielles
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 - **Élections présidentielles 2017** :
 
@@ -347,7 +347,7 @@ datasets:
      - Vote des Français établis hors de France : [Résultats 1er tour](http://static.data.gouv.fr/cb/a1ed09011e8d34adabb3085d1d78771bcad61eec8f07ba1956cb2c7fbddc24.csv)
     - Vote des Français établis hors de France : [Résultats 2nd tour](http://static.data.gouv.fr/07/a8f04b7b7798ad41dd89423d15c93be87cd4b9988d7f558f4883f29ff01af0.csv)
 
-### Données du Centre de données socio-politiques de [Sciences Po](https://www.data.gouv.fr/fr/organizations/sciences-po/)
+### Données du Centre de données socio-politiques de [Sciences Po](/organizations/sciences-po/)
 
 - **Élections présidentielles 2012** :
      - Résultats 1er tour : [par circonscriptions législatives](https://www.data.gouv.fr/s/resources/elections-presidentielles-1965-2012-1/20150204-183733/cdsp_presi2012t1_circ.csv)
@@ -417,7 +417,7 @@ datasets:
 
 ## Élections Sénatoriales
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 -   **Élections sénatoriales 1992** :
     -   Résultats 1er et 2nd tours : [Résultats du scrutin proportionnel et liste des élus](http://static.data.gouv.fr/12/b5c4a60f1fcddaefb3de0880e1a1e231d5a2928e63e1203036572ba332fa95.xls)
@@ -438,15 +438,15 @@ datasets:
 -   **Élections sénatoriales partielles du 6 septembre 2015 dans les départements du Cantal et du Gers** :
     -   Résultats 1er et 2nd tours : [Résultats du scrutin proportionnel et liste des élus](https://www.data.gouv.fr/s/resources/resultats-des-elections-senatoriales-partielles-du-6-septembre-2015-cantal-gers/20150908-114758/senatoriales_partielles_6_sept_2015.xlsx)
 -   **Élections sénatoriales 2017** :
-    -   [Liste des candidats](https://www.data.gouv.fr/fr/datasets/elections-senatoriales-du-24-septembre-2017-liste-des-candidats/)
-    -   [Résultats du scrutin majoritaire, tours 1 et 2, scrutin proportionnel et liste des élus](https://www.data.gouv.fr/fr/datasets/elections-senatoriales-2017-resultats/)
+    -   [Liste des candidats](/datasets/elections-senatoriales-du-24-septembre-2017-liste-des-candidats/)
+    -   [Résultats du scrutin majoritaire, tours 1 et 2, scrutin proportionnel et liste des élus](/datasets/elections-senatoriales-2017-resultats/)
 -   **Élections sénatoriales 2020** :
-    -   [Candidatures au premier tour](https://www.data.gouv.fr/fr/datasets/senatoriales-2020-candidatures-au-t1/)
-    -   [Résultats du scrutin majoritaire, tours 1 et 2 et scrutin proportionnel](https://www.data.gouv.fr/fr/datasets/senatoriales-2020-resultats/)
+    -   [Candidatures au premier tour](/datasets/senatoriales-2020-candidatures-au-t1/)
+    -   [Résultats du scrutin majoritaire, tours 1 et 2 et scrutin proportionnel](/datasets/senatoriales-2020-resultats/)
 
 ##Élections régionales
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 - **Élections régionales 2015** (et de l’Assemblée de Corse, des Assemblées de Guyanes et de Martinique) :
     - Résultats 1er tour : [par bureaux de vote](https://www.data.gouv.fr/s/resources/elections-regionales-2015-et-des-assemblees-de-corse-de-guyane-et-de-martinique-resultats-par-bureaux-de-vote-tour-1/20151210-082528/RG15_Bvot_T1.txt)
@@ -472,7 +472,7 @@ datasets:
     - Résultats 1er et 2nd tours : [par régions et départements](http://static.data.gouv.fr/0d/899afa4aedca3c4077239ef7c346de3e38c9acbc1ee2adcff3425251e531ca.xls)
 
 
-### Données du Centre de données socio-politiques de [Sciences Po](https://www.data.gouv.fr/fr/organizations/sciences-po/)
+### Données du Centre de données socio-politiques de [Sciences Po](/organizations/sciences-po/)
 
 - **Élections régionales 2010** (et de l’Assemblée de Corse, des Assemblées de Guyane et de Martinique) :
     - Résultats 1er tour : [par circonscriptions législatives](https://www.data.gouv.fr/s/resources/elections-regionales-1986-2010/20150204-160603/cdsp_regio2010t1_circ.csv)
@@ -505,7 +505,7 @@ datasets:
 
 ## Élections Départementales
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 -   **Élections départementales 2015** :
     -   Candidatures au 1er tour : [Fichier consolidé](https://www.data.gouv.fr/s/resources/elections-departementales-2015-candidatures-1er-tour/community/20150309-124441/Dep_15_Candidatures_T1_c_09_03_2015.xlsx)
@@ -525,12 +525,12 @@ datasets:
 ## Élections métropolitaines
 
 - **Élections à la Métropole de Lyon du 2020**
-  - [Résultats du premier tour](https://www.data.gouv.fr/fr/datasets/resultats-du-premier-tour-des-elections-a-la-metropole-de-lyon-15-mars-2020/)
-  - [Résultats du second tour](https://www.data.gouv.fr/fr/datasets/resultats-du-second-tour-des-elections-a-la-metropole-de-lyon-28-juin-2020/)
+  - [Résultats du premier tour](/datasets/resultats-du-premier-tour-des-elections-a-la-metropole-de-lyon-15-mars-2020/)
+  - [Résultats du second tour](/datasets/resultats-du-second-tour-des-elections-a-la-metropole-de-lyon-28-juin-2020/)
 
 ## Élections cantonales
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 -   **Élections cantonales 1992** :
     -   Résultats tours 1 et 2 : [par communes](http://static.data.gouv.fr/6a/4fe591fdd19a1235dc780c13d61442e072972f8c3bf2aeb44ec62aab3ac59b.xls)
@@ -568,7 +568,7 @@ datasets:
 -   **Autre** :
     -   [Contours des cantons électoraux département en 2015](https://www.data.gouv.fr/s/resources/contours-des-cantons-electoraux-departementaux-2015/20150220-161605/Cartes_cantons_2015.zip)
 
-### Données du Centre de données socio-politiques de [Sciences Po](https://www.data.gouv.fr/fr/organizations/sciences-po/)
+### Données du Centre de données socio-politiques de [Sciences Po](/organizations/sciences-po/)
 
 
 -   **Élections cantonales 1988** :
@@ -629,7 +629,7 @@ datasets:
     
 ## Référendums et  Consultations
 
-### Données du [Ministère de l’Intérieur](https://www.data.gouv.fr/fr/organizations/ministere-de-l-interieur/)
+### Données du [Ministère de l’Intérieur](/organizations/ministere-de-l-interieur/)
 
 -   **Référendum de 1992** :
     -   Résultats : [par communes](http://static.data.gouv.fr/58/b4aad8b8f738ebb48fa31ca00825c452244406ee8ae53831ef398e554852ca.xls)
@@ -649,10 +649,10 @@ datasets:
     -   Résultats : [par régions, départements, circonscriptions législatives et cantons](http://static.data.gouv.fr/5b/cb5f907d61ecd1036720dd4be906ddb46431e90a88e3259b145759eb0bfdec.xls)
 
 -   **Consultation du 26 juin 2016 des électeurs des communes de la Loire-Atlantique sur le projet de transfert de l’aéroport de Nantes-Atlantique sur la commune de Notre-Dame-des-Landes** :
-    -   Résultats : [Résultats définitifs de la consultation validés par la Commission de recensement](https://www.data.gouv.fr/fr/datasets/r/b47a8e2b-4e93-4016-902f-ecd368dd5924)
+    -   Résultats : [Résultats définitifs de la consultation validés par la Commission de recensement](/datasets/r/b47a8e2b-4e93-4016-902f-ecd368dd5924)
     
 -  **Consultation des électeurs de la Nouvelle-Calédonie du 4 octobre 2020**
-   -   [Résultats par bureau de vote](https://www.data.gouv.fr/fr/datasets/consultation-des-electeurs-de-la-nouvelle-caledonie-du-4-octobre-2020/)
+   -   [Résultats par bureau de vote](/datasets/consultation-des-electeurs-de-la-nouvelle-caledonie-du-4-octobre-2020/)
 
 ## Ressources/ Documentations
 

--- a/pages/donnees-machine-learning.md
+++ b/pages/donnees-machine-learning.md
@@ -144,3 +144,8 @@ Ici nous avons choisi les données de 2019 et nous avons concaténé les jeux di
 *Ce jeu de données présente les voeux de poursuite d’études et de réorientation dans l’enseignement supérieur ainsi que les propositions des établissements pour chaque formation — hors apprentissage — à la fin du processus d’affectation de la plateforme Parcoursup pour la session 2020*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/1d916b7c-bd4c-4951-845a-70f7ad7c17db.html)
   - [Réutilisation data.gouv.fr](/reuses/classifions-parcoursup/)
+
+### Traitement automatique du langage
+
+[PIAF]( /datasets/piaf-le-dataset-francophone-de-questions-reponses/) un jeu de données de questions réponses francophones
+  - [Réutilisation data.gouv.fr]( /reuses/modele-de-questions-reponses-francophone/)

--- a/pages/donnees-machine-learning.md
+++ b/pages/donnees-machine-learning.md
@@ -32,7 +32,7 @@ datasets:
 
 Cette page a pour vocation de référencer les principaux jeux de données qui se prêtent bien à l’apprentissage automatique (*Machine Learning*) disponibles sur data.gouv.fr. Elle n’est pas exhaustive et est ouverte aux contributions.
 
-> Pour en savoir plus sur le contexte dans lequel s’inscrit ce catalogue et sur sa constuction vous pouvez lire [l’article dédié](https://www.data.gouv.fr/fr/posts/les-donnees-ouvertes-pour-lapprentissage-automatique-machine-learning). 
+> Pour en savoir plus sur le contexte dans lequel s’inscrit ce catalogue et sur sa constuction vous pouvez lire [l’article dédié](/posts/les-donnees-ouvertes-pour-lapprentissage-automatique-machine-learning). 
 
 Nous proposons ici un **catalogue des jeux de données identifiés comme exploitables par des algorithmes d’apprentissage automatique regroupés par tâche.**
 Chaque jeu est accompagné : 
@@ -46,79 +46,79 @@ Chaque jeu est accompagné :
 ### Régression
 
 
-[**Émissions de CO2 et de polluants des véhicules commercialisés en France**](https://www.data.gouv.fr/fr/datasets/emissions-de-co2-et-de-polluants-des-vehicules-commercialises-en-france/)
+[**Émissions de CO2 et de polluants des véhicules commercialisés en France**](/datasets/emissions-de-co2-et-de-polluants-des-vehicules-commercialises-en-france/)
 *Ce jeu de données présente l’ensemble des caractéristiques techniques des véhicules commercialisés en France en 2013, ainsi que les consommations de carburant, les émissions de CO2 et de polluants de l’air.*  
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/6ff09b59-84ca-4346-a8d1-3587ed94da15.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/6ff09b59-84ca-4346-a8d1-3587ed94da15/README.html) (target variable: *CO2*)
-  - [Réutilisation data.gouv](https://www.data.gouv.fr/fr/reuses/predict-co2-emissions-of-different-cars/)
+  - [Réutilisation data.gouv](/reuses/predict-co2-emissions-of-different-cars/)
 
 [**Liste des logements proposés en Airbnb sur Bordeaux**](https://www.data.gouv.fr/en/datasets/liste-des-logements-proposes-en-airbnb-sur-bordeaux/)
 C*e jeu de données contient un recensement des caractéristiques des logements (prix par nuit, nombre de pièces, services disponibles, etc.) proposés par Airbnb à Bordeaux.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/123e1c18-37e0-4147-ad65-768320387800.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/123e1c18-37e0-4147-ad65-768320387800/README.html) (target variable: *PrixNuitee*)
 
-[**AGRIBALYSE® - Synthèse**](https://www.data.gouv.fr/fr/datasets/agribalyse-r-synthese-1/)
+[**AGRIBALYSE® - Synthèse**](/datasets/agribalyse-r-synthese-1/)
 *AGRIBALYSE® est une base de données de référence des indicateurs d’impacts environnementaux des produits agricoles et des produits alimentaires consommés en France. Vous trouverez le recensement des caractéristiques de plusieurs aliments ainsi que les émissions de polluants qui leur sont associés.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/c763b24a-a0fe-4e77-9586-3d5453c631cd.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/c763b24a-a0fe-4e77-9586-3d5453c631cd/README.html) (target variable: *DQR — Note de qualité de la donnée (1 excellente ; 5 très faible)*)
 
-[**Données carroyées issues du dispositif sur les revenus localisés fiscaux et sociaux**](https://www.data.gouv.fr/fr/datasets/donnees-carroyees-issues-du-dispositif-sur-les-revenus-localises-fiscaux-et-sociaux-filosofi/)
+[**Données carroyées issues du dispositif sur les revenus localisés fiscaux et sociaux**](/datasets/donnees-carroyees-issues-du-dispositif-sur-les-revenus-localises-fiscaux-et-sociaux-filosofi/)
 *Ces données proviennent du dispositif sur les revenus localisés sociaux et fiscaux (FiLoSoFi) et contiennent des variables sur la structure par âge des individus, sur les caractéristiques des ménages et des logements et sur les revenus de l’année 2015. On se restreint ici au jeu de données correspondant à la France métropolitaine.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/aa50b408-49f4-4608-97fd-dd8fb21ef239.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/aa50b408-49f4-4608-97fd-dd8fb21ef239/README.html) (target variable: *Log_soc*)
-  - [Réutilisation data.gouv.fr](https://www.data.gouv.fr/fr/reuses/deep-learning-pour-la-prediction-de-la-densite/)
+  - [Réutilisation data.gouv.fr](/reuses/deep-learning-pour-la-prediction-de-la-densite/)
 
-[**Demande de valeurs foncières**](https://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres/) 
+[**Demande de valeurs foncières**](/datasets/demandes-de-valeurs-foncieres/) 
 *Publié et produit par la direction générale des finances publiques, ce jeu de données permet de connaître les transactions immobilières intervenues au cours des cinq dernières années sur le territoire métropolitain et les DOM-TOM. On se restreint ici aux données du premier trimestre de 2020.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/90a98de0-f562-4328-aa16-fe0dd1dca60f.html)
   - [Modèle](https://github.com/etalab-ia/DGML/blob/main/docs/automodels/90a98de0-f562-4328-aa16-fe0dd1dca60f/README.md) (target variable: *valeur foncière*)
 
-[**Concentration horaire des polluants —Air ambiant —Lig'Air - Orléans Métropole**](https://www.data.gouv.fr/fr/datasets/concentration-horaire-des-polluants-air-ambiant-ligair-orleans-metropole/)
+[**Concentration horaire des polluants —Air ambiant —Lig'Air - Orléans Métropole**](/datasets/concentration-horaire-des-polluants-air-ambiant-ligair-orleans-metropole/)
 *Ce jeu de données contient les concentrations moyennes horaires des principaux polluants de l’air réglementés dans la région Centre-Val de Loire : monoxyde d’azote NO et dioxyde d’azote NO2, particules en suspension PM10, particules en suspension PM2.5, ozone O3, monoxyde de carbone CO. Les données sont souvent mises à jour et peuvent donc évoluer.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/ce203343-6ed9-4fd3-b310-e553ae437f6d.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/AutoML_conc_poll_reg/README.html) (target variable: *valeur*)
 
-[**Inventaire de gaz à effet de serre territorialisé**](https://www.data.gouv.fr/fr/datasets/inventaire-de-gaz-a-effet-de-serre-territorialise/#_)
+[**Inventaire de gaz à effet de serre territorialisé**](/datasets/inventaire-de-gaz-a-effet-de-serre-territorialise/#_)
 *Ce jeu de données recense les effets de l’ensemble des gaz à effet de serre, en détaillant les émissions par commune et par secteur en 2016.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/4072eb84-5093-4490-96e6-bcec87f51ea8.html)
 
-[**Insertion professionnelle des diplômés de Master en universités et établissements assimilés**](https://www.data.gouv.fr/fr/datasets/insertion-professionnelle-des-diplomes-de-master-en-universites-et-etablissements-assimil-0/#_)
+[**Insertion professionnelle des diplômés de Master en universités et établissements assimilés**](/datasets/insertion-professionnelle-des-diplomes-de-master-en-universites-et-etablissements-assimil-0/#_)
 *Ce jeu contient les données issues de l’opération nationale de collecte de données sur l’insertion professionnelle (taux d’insertion, salaire, etc.) des diplômés de Master.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/a27a4212-6732-408e-85e4-819ce897046b.html)
 
 ### Classification
 
-[**Bases de données annuelles des accidents corporels de la circulation routière - Années de 2005 à 2019**](https://www.data.gouv.fr/fr/datasets/bases-de-donnees-annuelles-des-accidents-corporels-de-la-circulation-routiere-annees-de-2005-a-2019/#_)
+[**Bases de données annuelles des accidents corporels de la circulation routière - Années de 2005 à 2019**](/datasets/bases-de-donnees-annuelles-des-accidents-corporels-de-la-circulation-routiere-annees-de-2005-a-2019/#_)
 *Ces jeux de données répertorient l’intégralité des accidents corporels de la circulation intervenus durant une année précise en France métropolitaine et dans les DOM-TOM. Ils comprennent des informations de localisation de l’accident ainsi que des informations concernant les caractéristiques de l’accident et son lieu, les véhicules impliqués et leurs victimes.
 Ici nous avons choisi les données de 2019 et nous avons concaténé les jeux disponibles (caractéristique, lieux, véhicule, usager) dans un unique jeu de données.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/6af37c98-0933-4ae4-8380-5f63212fb52a.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/6af37c98-0933-4ae4-8380-5f63212fb52a/README.html) (target variable: *grav*)
-  - [Réutilisation data.gouv.fr](https://www.data.gouv.fr/fr/reuses/machine-learning-pour-predire-la-gravite-des-accidents/)
+  - [Réutilisation data.gouv.fr](/reuses/machine-learning-pour-predire-la-gravite-des-accidents/)
 
-[**Arbres urbains**](https://www.data.gouv.fr/fr/datasets/arbres-urbains/)
+[**Arbres urbains**](/datasets/arbres-urbains/)
 *Ce jeu de données comprend des informations sur la localisation, l’espèce, les dimensions, les spécificités et l’état de santé du patrimoine arboré de la commune de Saint-Germain-en-Laye.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/96f4164d-956d-4c1c-b161-68724eb0ccdc.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/96f4164d-956d-4c1c-b161-68724eb0ccdc/README.html) (target variable: *classification_diagnostic*)
 
-[**Résultats des contrôles officiels sanitaires : dispositif d’information « Alim’confiance »**](https://www.data.gouv.fr/fr/datasets/resultats-des-controles-officiels-sanitaires-dispositif-dinformation-alimconfiance/) 
+[**Résultats des contrôles officiels sanitaires : dispositif d’information « Alim’confiance »**](/datasets/resultats-des-controles-officiels-sanitaires-dispositif-dinformation-alimconfiance/) 
 *Ce jeu de données contient le résultat des contrôles officiels en sécurité sanitaire des aliments réalisés dans tous les établissements de la chaîne alimentaire : abattoirs, commerces de détail (métiers de bouche, restaurants, supermarchés, marchés, vente à la ferme, etc.), restaurants collectifs et établissements agroalimentaires.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/fff0cc27-977b-40d5-9c11-f7e4e79a0b72.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/fff0cc27-977b-40d5-9c11-f7e4e79a0b72/README.html) (target variable : *Synthese_eval_sanit*)
-  - [Réutilisation data.gouv.fr](https://www.data.gouv.fr/fr/reuses/predire-la-qualite-sanitaire-dun-etablissement-alimentaire/)
+  - [Réutilisation data.gouv.fr](/reuses/predire-la-qualite-sanitaire-dun-etablissement-alimentaire/)
 
-[**Concentration horaire des polluants —Air ambiant —Lig'Air - Orléans Métropole**](https://www.data.gouv.fr/fr/datasets/concentration-horaire-des-polluants-air-ambiant-ligair-orleans-metropole/)
+[**Concentration horaire des polluants —Air ambiant —Lig'Air - Orléans Métropole**](/datasets/concentration-horaire-des-polluants-air-ambiant-ligair-orleans-metropole/)
 *Ce jeu de données contient les concentrations moyennes horaires des principaux polluants réglementés dans l’air sur la région Centre-Val de Loire : monoxyde d’azote NO et dioxyde d’azote NO2, particules en suspension PM10, particules en suspension PM2.5, ozone O3, monoxyde de carbone CO. Les données sont souvent mises à jour et peuvent donc évoluer.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/ce203343-6ed9-4fd3-b310-e553ae437f6d.html)
   - [Modèle](https://etalab-ia.github.io/DGML/automodels/AutoML_conc_poll_class/README.html) (target variable: *nom_poll*)
 
-[**Données sur l’orientation des toits en France**](https://www.data.gouv.fr/fr/datasets/donnees-brutes-de-contribution-anonymisees/#resource-849fa6c2-7d0b-46b8-9814-29bf18b35bfa)
+[**Données sur l’orientation des toits en France**](/datasets/donnees-brutes-de-contribution-anonymisees/#resource-849fa6c2-7d0b-46b8-9814-29bf18b35bfa)
 *Ces jeux de données, réutilisés dans le projet [*OpenSolar*]( https://github.com/opensolarmap/solml), se composent d’un datasses *contributions* (id OpenStreetMap du bâtiment ainsi que l’orientation du toit) et *bâtiments* (id, géométrie, surface du bâtiment et orientation du toit).*
   - [Profiling du dataset bâtiments](https://etalab-ia.github.io/DGML/profilings/849fa6c2-7d0b-46b8-9814-29bf18b35bfa.html), 
   - [Profiling du dataset contributions](https://etalab-ia.github.io/DGML/profilings/aef0f017-ba25-4772-b0e7-8693308d4404.html)
 
 ### Séries temporelles
 
-[Données hospitalières relatives à l’épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/) 
+[Données hospitalières relatives à l’épidémie de COVID-19](/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/) 
 *Cinq jeux de données différents sont proposés contenant des données sur les hospitalisations, les réanimations et les décès, regroupés par région, puis par département et par sexe, par classe d’âge et par établissements.*
   - [Profiling du jeu de données par région et classe d’âge du patient](https://etalab-ia.github.io/DGML/profilings/08c18e08-6780-452d-9b8c-ae244ad529b3.html) 
   - [Profiling du jeu de données par département](https://etalab-ia.github.io/DGML/profilings/41b9bd2a-b5b6-4271-8878-e45a8902ef00.html),
@@ -130,17 +130,17 @@ Ici nous avons choisi les données de 2019 et nous avons concaténé les jeux di
 *Quatre jeux de données qui contiennent les données quotidiennes de SOS Médecins et des urgences hospitalières en relation à l’épidémie de Covid-19. On s’intéresse ici au jeu de données des passages quotidiens par département et par tranche d’âge.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/eceb9fb4-3ebc-4da3-828d-f5939712600a.html)
 
-[Indicateurs de suivi de l’épidémie de COVID-19 ](https://www.data.gouv.fr/fr/datasets/indicateurs-de-suivi-de-lepidemie-de-covid-19/#_)
+[Indicateurs de suivi de l’épidémie de COVID-19 ](/datasets/indicateurs-de-suivi-de-lepidemie-de-covid-19/#_)
 *Les données mises à disposition présentent la valeur quotidienne de 4 indicateurs (activité épidémique, taux de positivité des tests virologiques, évolution du R0, tension hospitalière sur la capacité en réanimation) au niveau national et départemental depuis le 15 mars 2020. On s’intéresse ici aux données par département.*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/4acad602-d8b1-4516-bc71-7d5574d5f33e.html)
 
-[Éclairage public de la ville de Béthune 2017-2019 ](https://www.data.gouv.fr/fr/datasets/eclairage-public-de-la-ville-de-bethune-2017-2019-1/#_)
+[Éclairage public de la ville de Béthune 2017-2019 ](/datasets/eclairage-public-de-la-ville-de-bethune-2017-2019-1/#_)
 *Ce jeu de données contient des données sur l’éclairage public de la ville de Béthune (62400) sur la période de janvier 2017 à décembre 2019. En particulier : la consommation en kWhEN, la dépense en euros TTC, l’émission GES (KgCO2).*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/fd34262e-355d-4ac6-bac2-06c1b52fa42a.html)
 
 ### Apprentissage non supervisé
 
-[Parcoursup 2020](https://www.data.gouv.fr/fr/datasets/parcoursup-2020-voeux-de-poursuite-detudes-et-de-reorientation-dans-lenseignement-superieur-et-reponses-des-etablissements/#resource-1d916b7c-bd4c-4951-845a-70f7ad7c17db)
+[Parcoursup 2020](/datasets/parcoursup-2020-voeux-de-poursuite-detudes-et-de-reorientation-dans-lenseignement-superieur-et-reponses-des-etablissements/#resource-1d916b7c-bd4c-4951-845a-70f7ad7c17db)
 *Ce jeu de données présente les voeux de poursuite d’études et de réorientation dans l’enseignement supérieur ainsi que les propositions des établissements pour chaque formation — hors apprentissage — à la fin du processus d’affectation de la plateforme Parcoursup pour la session 2020*
   - [Profiling](https://etalab-ia.github.io/DGML/profilings/1d916b7c-bd4c-4951-845a-70f7ad7c17db.html)
-  - [Réutilisation data.gouv.fr](https://www.data.gouv.fr/fr/reuses/classifions-parcoursup/)
+  - [Réutilisation data.gouv.fr](/reuses/classifions-parcoursup/)

--- a/pages/donnees-renovation-logements-et-batiments.md
+++ b/pages/donnees-renovation-logements-et-batiments.md
@@ -30,55 +30,51 @@ datasets:
 ---
 # Les données relatives à la rénovation énergétique des logements et bâtiments
 
-## Données de [l'ADEME](https://www.data.gouv.fr/fr/organizations/ademe/)
+## Données de [l'ADEME](/organizations/ademe/)
 
 ### Diagnostics de performance énergétique
 
-- [Les diagnostics de performance énergétique pour les logements par habitation](https://www.data.gouv.fr/fr/datasets/diagnostics-de-performance-energetique-pour-les-logements-par-habitation/)
-- [Les diagnostics de performance énergétique pour les bâtiments publics](https://www.data.gouv.fr/fr/datasets/diagnostics-de-performance-energetique-pour-les-batiments-publics/)
+- [Les diagnostics de performance énergétique pour les logements par habitation](/datasets/diagnostics-de-performance-energetique-pour-les-logements-par-habitation/)
+- [Les diagnostics de performance énergétique pour les bâtiments publics](/datasets/diagnostics-de-performance-energetique-pour-les-batiments-publics/)
 
 Ces données sont également accessibles via les API correspondantes sur le site api.gouv.fr :
 
 - [Accéder à l'API DPE pour les logements](https://api.gouv.fr/les-api/api_dpe_logements)
 - [Accéder à l'API DPE pour les bâtiments publics](https://api.gouv.fr/les-api/api_dpe_batiments_publics)
 
-Pour plus d'informations sur la base DPE et ses usages possibles, [voir aussi l'article de blog "La base des diagnostics de performance énergétique DPE : quelles données, pour quels usages ?"](https://www.data.gouv.fr/fr/posts/la-base-des-diagnostics-de-performance-energetique-dpe/) sur data.gouv.fr.
+Pour plus d'informations sur la base DPE et ses usages possibles, [voir aussi l'article de blog "La base des diagnostics de performance énergétique DPE : quelles données, pour quels usages ?"](/posts/la-base-des-diagnostics-de-performance-energetique-dpe/) sur data.gouv.fr.
 
 ### Aides financières à la rénovation énergétique 
 
-- [Nombre de dispositifs d’aides financières à la rénovation énergétique, par région](https://www.data.gouv.fr/fr/datasets/nombre-de-dispositifs-daides-financieres-a-la-renovation-energetique-par-region/)
-- [Dispositifs d’aides financières à la rénovation énergétique](https://www.data.gouv.fr/fr/datasets/dispositifs-daides-financieres-a-la-renovation-energetique/)
+- [Nombre de dispositifs d’aides financières à la rénovation énergétique, par région](/datasets/nombre-de-dispositifs-daides-financieres-a-la-renovation-energetique-par-region/)
+- [Dispositifs d’aides financières à la rénovation énergétique](/datasets/dispositifs-daides-financieres-a-la-renovation-energetique/)
 
 ### Estimation des coûts de rénovation énergétique
 
-- [Données de l'étude "Individualisation des frais de chauffage"](https://www.data.gouv.fr/fr/datasets/donnees-de-letude-individualisation-des-frais-de-chauffage/)
-- [Coûts des travaux de rénovation énergétique](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-energetique/)
-- [Coûts des travaux de rénovation - Isolation](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-isolation/)
-- [Coûts des travaux de rénovation - ECS](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-ecs/)
-- [Coûts des travaux de rénovation - Chauffage](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-chauffage/)
-- [Coûts des travaux de rénovation - Menuiseries](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-menuiseries/)
-- [Coûts des travaux de rénovation - Photovoltaïque](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-photovoltaique/)
-- [Coûts des travaux de rénovation - Ventilation](https://www.data.gouv.fr/fr/datasets/couts-des-travaux-de-renovation-ventilation/)
+- [Données de l'étude "Individualisation des frais de chauffage"](/datasets/donnees-de-letude-individualisation-des-frais-de-chauffage/)
+- [Coûts des travaux de rénovation énergétique](/datasets/couts-des-travaux-de-renovation-energetique/)
+- [Coûts des travaux de rénovation - Isolation](/datasets/couts-des-travaux-de-renovation-isolation/)
+- [Coûts des travaux de rénovation - ECS](/datasets/couts-des-travaux-de-renovation-ecs/)
+- [Coûts des travaux de rénovation - Chauffage](/datasets/couts-des-travaux-de-renovation-chauffage/)
+- [Coûts des travaux de rénovation - Menuiseries](/datasets/couts-des-travaux-de-renovation-menuiseries/)
+- [Coûts des travaux de rénovation - Photovoltaïque](/datasets/couts-des-travaux-de-renovation-photovoltaique/)
+- [Coûts des travaux de rénovation - Ventilation](/datasets/couts-des-travaux-de-renovation-ventilation/)
 
 ### Energie et patrimoine communal
 
-- [Energie et patrimoine communal -1- Description](https://www.data.gouv.fr/fr/datasets/energie-et-patrimoine-communal-1-description/)
-- [Energie et patrimoine communal -2- Energie](https://www.data.gouv.fr/fr/datasets/energie-et-patrimoine-communal-2-energie/)
-- [Energie et patrimoine communal -3- Divers](https://www.data.gouv.fr/fr/datasets/energie-et-patrimoine-communal-3-divers/)
-- [Energie et patrimoine communal -4- Dépenses et consommation](https://www.data.gouv.fr/fr/datasets/energie-et-patrimoine-communal-4-depenses-et-consommation/)
-- [Energie et patrimoine communal -5- Bâtiments](https://www.data.gouv.fr/fr/datasets/energie-et-patrimoine-communal-5-batiments/)
+- [Energie et patrimoine communal -1- Description](/datasets/energie-et-patrimoine-communal-1-description/)
+- [Energie et patrimoine communal -2- Energie](/datasets/energie-et-patrimoine-communal-2-energie/)
+- [Energie et patrimoine communal -3- Divers](/datasets/energie-et-patrimoine-communal-3-divers/)
+- [Energie et patrimoine communal -4- Dépenses et consommation](/datasets/energie-et-patrimoine-communal-4-depenses-et-consommation/)
+- [Energie et patrimoine communal -5- Bâtiments](/datasets/energie-et-patrimoine-communal-5-batiments/)
 
 ### Marchés et emplois de l'efficacité énergétique
 
-- [Marchés et emploi de l'efficacité énergétique et des EnR - EnR (2019)](https://www.data.gouv.fr/fr/datasets/marches-et-emploi-de-lefficacite-energetique-et-des-enr-enr-2019/)
-- [Marchés et emploi de l'efficacité énergétique et des EnR - Transport (2019)](https://www.data.gouv.fr/fr/datasets/marches-et-emploi-de-lefficacite-energetique-et-des-enr-transport-2019/)
-- [Marchés et emploi de l'efficacité énergétique et des EnR - Bâtiment (2019)](https://www.data.gouv.fr/fr/datasets/marches-et-emploi-de-lefficacite-energetique-et-des-enr-batiment-2019/)
+- [Marchés et emploi de l'efficacité énergétique et des EnR - EnR (2019)](/datasets/marches-et-emploi-de-lefficacite-energetique-et-des-enr-enr-2019/)
+- [Marchés et emploi de l'efficacité énergétique et des EnR - Transport (2019)](/datasets/marches-et-emploi-de-lefficacite-energetique-et-des-enr-transport-2019/)
+- [Marchés et emploi de l'efficacité énergétique et des EnR - Bâtiment (2019)](/datasets/marches-et-emploi-de-lefficacite-energetique-et-des-enr-batiment-2019/)
 
 ## Données du Ministère de la Cohésion des Territoires
 
-- [Observatoire des performances énergétiques OPE](https://www.data.gouv.fr/fr/datasets/observatoire-des-performances-energetiques/)
-- [Base des permis de construire (Sitadel)](https://www.data.gouv.fr/fr/datasets/base-des-permis-de-construire-sitadel/)
-
-
-
-
+- [Observatoire des performances énergétiques OPE](/datasets/observatoire-des-performances-energetiques/)
+- [Base des permis de construire (Sitadel)](/datasets/base-des-permis-de-construire-sitadel/)

--- a/pages/donnees-sante.md
+++ b/pages/donnees-sante.md
@@ -43,39 +43,39 @@ datasets:
 
 ## Les données du [Ministère des Solidarités et de la Santé](https://www.data.gouv.fr/en/organizations/ministere-des-solidarites-et-de-la-sante/)
 
-- [Base FINESS des établissements du domaine sanitaire et social](https://www.data.gouv.fr/fr/datasets/finess-extraction-du-fichier-des-etablissements/)
-- [FINESS Extraction des principales nomenclatures](https://www.data.gouv.fr/fr/datasets/finess-extraction-des-principales-nomenclatures/)
-- [FINESS assistance aux utilisateurs - FAQ](https://www.data.gouv.fr/fr/datasets/finess-assistance-aux-utilisateurs-1/)
-- [Base de données publique des médicaments](https://www.data.gouv.fr/fr/datasets/base-de-donnees-publique-des-medicaments-base-officielle/)
-- [Transparence-santé](https://www.data.gouv.fr/fr/datasets/transparence-sante-1/)
+- [Base FINESS des établissements du domaine sanitaire et social](/datasets/finess-extraction-du-fichier-des-etablissements/)
+- [FINESS Extraction des principales nomenclatures](/datasets/finess-extraction-des-principales-nomenclatures/)
+- [FINESS assistance aux utilisateurs - FAQ](/datasets/finess-assistance-aux-utilisateurs-1/)
+- [Base de données publique des médicaments](/datasets/base-de-donnees-publique-des-medicaments-base-officielle/)
+- [Transparence-santé](/datasets/transparence-sante-1/)
 
-## Les données de la [Caisse Primaire d'Assurance Maladie](https://www.data.gouv.fr/fr/organizations/caisse-nationale-de-l-assurance-maladie-des-travailleurs-salaries/)
+## Les données de la [Caisse Primaire d'Assurance Maladie](/organizations/caisse-nationale-de-l-assurance-maladie-des-travailleurs-salaries/)
 
-- [Annuaire santé de la CNAM](https://www.data.gouv.fr/fr/datasets/annuaire-sante-de-la-cnam/)
-- [Open Medic : base complète sur les dépenses de médicaments interrégimes](https://www.data.gouv.fr/fr/datasets/open-medic-base-complete-sur-les-depenses-de-medicaments-interregimes/)
-- [Médicaments remboursés par l'assurance maladie](https://www.data.gouv.fr/fr/datasets/medicaments-rembourses-par-lassurance-maladie/)
-- [Dépenses annuelles d'assurance maladie 2012 - 2013 - 2014 - 2015 - 2016](https://www.data.gouv.fr/fr/datasets/depenses-annuelles-d-assurance-maladie/)
-- [Actes de biologie médicale remboursés par l'Asurance Maladie](https://www.data.gouv.fr/fr/datasets/actes-de-biologie-medicale-rembourses-par-lasurance-maladie/)
-- [Dépenses d' assurance maladie hors prestations hospitalières (données nationales)](https://www.data.gouv.fr/fr/datasets/depenses-d-assurance-maladie-hors-prestations-hospitalieres-donnees-nationales/)
-- [Open DAMIR : base complète sur les dépenses d'assurance maladie inter régimes](https://www.data.gouv.fr/fr/datasets/open-damir-base-complete-sur-les-depenses-dassurance-maladie-inter-regimes/)
-- [Personnes en affection de longue durée (ALD)](https://www.data.gouv.fr/fr/datasets/personnes-en-affection-de-longue-duree-ald/)
-- [Open LPP : base complète sur les dépenses de dispositifs médicaux inscrits à la liste de produits et prestations (LPP) interrégimes](https://www.data.gouv.fr/fr/datasets/open-lpp-base-complete-sur-les-depenses-de-dispositifs-medicaux-inscrits-a-la-liste-de-produits-et-prestations-lpp-interregimes/)
+- [Annuaire santé de la CNAM](/datasets/annuaire-sante-de-la-cnam/)
+- [Open Medic : base complète sur les dépenses de médicaments interrégimes](/datasets/open-medic-base-complete-sur-les-depenses-de-medicaments-interregimes/)
+- [Médicaments remboursés par l'assurance maladie](/datasets/medicaments-rembourses-par-lassurance-maladie/)
+- [Dépenses annuelles d'assurance maladie 2012 - 2013 - 2014 - 2015 - 2016](/datasets/depenses-annuelles-d-assurance-maladie/)
+- [Actes de biologie médicale remboursés par l'Asurance Maladie](/datasets/actes-de-biologie-medicale-rembourses-par-lasurance-maladie/)
+- [Dépenses d' assurance maladie hors prestations hospitalières (données nationales)](/datasets/depenses-d-assurance-maladie-hors-prestations-hospitalieres-donnees-nationales/)
+- [Open DAMIR : base complète sur les dépenses d'assurance maladie inter régimes](/datasets/open-damir-base-complete-sur-les-depenses-dassurance-maladie-inter-regimes/)
+- [Personnes en affection de longue durée (ALD)](/datasets/personnes-en-affection-de-longue-duree-ald/)
+- [Open LPP : base complète sur les dépenses de dispositifs médicaux inscrits à la liste de produits et prestations (LPP) interrégimes](/datasets/open-lpp-base-complete-sur-les-depenses-de-dispositifs-medicaux-inscrits-a-la-liste-de-produits-et-prestations-lpp-interregimes/)
 
 ## Les données de [Santé Publique France](https://www.data.gouv.fr/en/organizations/sante-publique-france/)
 
-- [Données hospitalières relatives à l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/)
-- [Données des urgences hospitalières et de SOS médecins relatives à l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-des-urgences-hospitalieres-et-de-sos-medecins-relatives-a-lepidemie-de-covid-19/)
-- [Données relatives aux tests de dépistage de COVID-19 réalisés en laboratoire de ville](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-tests-de-depistage-de-covid-19-realises-en-laboratoire-de-ville/)
-- [Données relatives aux résultats des tests virologiques COVID-19 SI-DEP](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-resultats-des-tests-virologiques-covid-19/)
-- [Niveaux d'excès de mortalité standardisé durant l'épidémie de COVID-19](https://www.data.gouv.fr/fr/datasets/niveaux-dexces-de-mortalite-standardise-durant-lepidemie-de-covid-19/)
-- [Taux d'incidence de l'épidémie de COVID-19 SI-DEP](https://www.data.gouv.fr/fr/datasets/taux-dincidence-de-lepidemie-de-covid-19/)
-- [Données de certification électronique des décès associés au COVID-19 (CEPIDC)](https://www.data.gouv.fr/fr/datasets/donnees-de-certification-electronique-des-deces-associes-au-covid-19-cepidc/)
-- [Capacité analytique de tests virologiques dans le cadre de l'épidémie COVID-19 SI-DEP](https://www.data.gouv.fr/fr/datasets/capacite-analytique-de-tests-virologiques-dans-le-cadre-de-lepidemie-covid-19/)
-- [Données d’enquête relatives à l’évolution des comportements et de la santé mentale pendant l’épidémie de COVID-19 (COVIPREV)](https://www.data.gouv.fr/fr/datasets/donnees-denquete-relatives-a-levolution-des-comportements-et-de-la-sante-mentale-pendant-lepidemie-de-covid-19-coviprev/)
+- [Données hospitalières relatives à l'épidémie de COVID-19](/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/)
+- [Données des urgences hospitalières et de SOS médecins relatives à l'épidémie de COVID-19](/datasets/donnees-des-urgences-hospitalieres-et-de-sos-medecins-relatives-a-lepidemie-de-covid-19/)
+- [Données relatives aux tests de dépistage de COVID-19 réalisés en laboratoire de ville](/datasets/donnees-relatives-aux-tests-de-depistage-de-covid-19-realises-en-laboratoire-de-ville/)
+- [Données relatives aux résultats des tests virologiques COVID-19 SI-DEP](/datasets/donnees-relatives-aux-resultats-des-tests-virologiques-covid-19/)
+- [Niveaux d'excès de mortalité standardisé durant l'épidémie de COVID-19](/datasets/niveaux-dexces-de-mortalite-standardise-durant-lepidemie-de-covid-19/)
+- [Taux d'incidence de l'épidémie de COVID-19 SI-DEP](/datasets/taux-dincidence-de-lepidemie-de-covid-19/)
+- [Données de certification électronique des décès associés au COVID-19 (CEPIDC)](/datasets/donnees-de-certification-electronique-des-deces-associes-au-covid-19-cepidc/)
+- [Capacité analytique de tests virologiques dans le cadre de l'épidémie COVID-19 SI-DEP](/datasets/capacite-analytique-de-tests-virologiques-dans-le-cadre-de-lepidemie-covid-19/)
+- [Données d’enquête relatives à l’évolution des comportements et de la santé mentale pendant l’épidémie de COVID-19 (COVIPREV)](/datasets/donnees-denquete-relatives-a-levolution-des-comportements-et-de-la-sante-mentale-pendant-lepidemie-de-covid-19-coviprev/)
 
-Voir aussi [la page sur les données relatives au COVID-19 en France](https://www.data.gouv.fr/fr/pages/donnees-coronavirus).
+Voir aussi [la page sur les données relatives au COVID-19 en France](/pages/donnees-coronavirus).
 
 ## Don du sang
 
-- [Dates et lieux de collectes de don du sang](https://www.data.gouv.fr/fr/datasets/dates-et-lieux-des-collectes-de-don-du-sang/)
+- [Dates et lieux de collectes de don du sang](/datasets/dates-et-lieux-des-collectes-de-don-du-sang/)
 - Les données de [l'établissement Français du sang](https://www.data.gouv.fr/en/organizations/etablissement-francais-du-sang/)


### PR DESCRIPTION
As per https://github.com/etalab/data.gouv.fr/issues/249 the URLs pointing to other pages on data.gouv.fr are now all relative, i.e. 

`[Données relatives aux livraisons de vaccins contre la COVID-19](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-livraisons-de-vaccins-contre-la-covid-19/)` ➡️ `[Données relatives aux livraisons de vaccins contre la COVID-19](/datasets/donnees-relatives-aux-livraisons-de-vaccins-contre-la-covid-19/)`

This is one of the PRs that will have to be merged for the *refonte graphique*, including https://github.com/etalab/datagouvfr-pages/pull/22

