### PR TITLE
Add licences on data.gouv.fr

### DIFF
--- a/pages/legal/licences/etalab-1.0.md
+++ b/pages/legal/licences/etalab-1.0.md
@@ -1,0 +1,57 @@
+# Licence Ouverte
+
+_Version de Octobre 2011_
+
+Vous pouvez réutiliser « l’Information » rendue disponible par le « Producteur » dans les libertés et les conditions prévues par la présente licence.
+
+## La réutilisation de l'information diffusée sous cette licence
+
+Le « Producteur » garantit au « Réutilisateur » le droit personnel, non exclusif et gratuit, de réutilisation de « l’Information » soumise à la présente licence, dans le monde entier et pour une durée illimitée, dans les libertés et les conditions exprimées ci-dessous.
+
+## Vous êtes libre de réutiLiser « L’information » :
+- Reproduire, copier, publier et transmettre « l’Information » ;
+- Diffuser et redistribuer « l’Information » ;
+- Adapter, modifier, extraire et transformer à partir de « l’Information »,
+notamment pour créer des « Informations dérivées » ;
+- Exploiter « l’Information » à titre commercial, par exemple en la combinant avec d’autres « Informations », ou en l’incluant dans votre propre produit ou application.
+
+## Sous réserve de :
+Mentionner la paternité de « l’Information » : sa source (a minima le nom du « Producteur ») et la date de sa dernière mise à jour.
+
+Le « Réutilisateur » peut notamment s’acquitter de cette condition en indiquant un ou des liens hypertextes (URL) renvoyant vers « l’Information » et assurant une mention effective de sa paternité.
+
+Cette mention de paternité ne doit ni conférer un caractère officiel à la réutilisation de « l’Information », ni suggérer une quelconque reconnaissance ou caution par le « Producteur », ou par toute autre entité publique, du « Réutilisateur » ou de sa réutilisation.
+
+## Responsabilité
+« L’Information » est mise à disposition telle que produite ou reçue par le « Producteur », sans autre garantie expresse ou tacite qui n’est pas prévue par la présente licence.
+
+Le « Producteur » garantit qu’il met à disposition gratuitement « l’Information » dans les libertés et les conditions définies par la présente licence. Il ne peut garantir l’absence de défauts ou d’irrégularités éventuellement contenues dans « l’Information ». Il ne garantit pas la fourniture continue de « l’Information ». Il ne peut être tenu pour responsable de toute perte, préjudice ou dommage de quelque sorte causé à des tiers du fait de la réutilisation.
+
+Le « Réutilisateur » est le seul responsable de la réutilisation de « l’Information ». La réutilisation ne doit pas induire en erreur des tiers quant au contenu de « l’Information », sa source et sa date de mise à jour.
+
+## Droits de propriété intellectuelle
+Le « Producteur » garantit que « l’Information » ne contient pas de droits de propriété intellectuelle appartenant à des tiers.
+
+Les éventuels « Droits de propriété intellectuelle » détenus par le « Producteur » sur des documents contenant « l’Information » ne font pas obstacle à la libre réutilisation de « l’Information ». Lorsque le « Producteur » détient des « Droits de propriété intellectuelle » sur des documents qui contiennent « l’Information », il les cède de façon non exclusive, à titre gracieux, pour le monde entier et pour toute la durée des « Droits de propriété intellectuelle », au « Réutilisateur » qui peut en faire tout usage conformément aux libertés et aux conditions définies par la présente licence.
+
+## Compatibilité de la présente licence
+Pour faciliter la réutilisation des « Informations », cette licence a été conçue pour être compatible avec toute licence libre qui exige a minima la mention de paternité. Elle est notamment compatible avec les licences « Open Government Licence » (OGL) du Royaume-Uni, « Creative Commons Attribution 2.0 » (CC-BY 2.0) de Creative Commons et « Open Data Commons Attribution » (ODC-BY) de l’Open Knowledge Foundation.
+
+## Droit applicable
+La présente licence est régie par le droit français.
+
+## Définitions
+### Droits de propriété intellectuelle*
+Il s’agit des droits identifiés comme tels par le Code de la propriété intellectuelle (droit d’auteur, droits voisins au droit d’auteur, droit sui generis des bases de données).
+
+### Information
+Il s’agit des données ou des informations proposées à la réutilisation dans les libertés et les conditions de cette licence.
+
+### Informations dérivées
+Il s’agit des nouvelles données ou informations qui ont été créés soit directement à partir « d’Informations », soit à partir d’une combinaison « d’Informations » et d’autres données ou informations qui ne seraient pas soumises à cette licence.
+
+### Producteur
+Il s’agit de l’entité qui produit « l’Information » et l’ouvre à la réutilisation dans les libertés et les conditions prévues par cette licence.
+
+### Réutilisateur
+Il s’agit de toute personne physique ou morale qui réutilise « l’Information » conformément aux libertés et aux conditions de cette licence.

--- a/pages/legal/licences/etalab-2.0.md
+++ b/pages/legal/licences/etalab-2.0.md
@@ -1,0 +1,79 @@
+# Licence Ouverte 2.0
+
+## Réutilisation de l’« Information » sous  cette licence
+
+Le « Concédant » concède au « Réutilisateur » un droit non exclusif et gratuit de libre  « Réutilisation » de l’« Information » objet de la présente licence, à des fins commerciales ou non, dans le monde entier et pour une durée illimitée, dans les conditions exprimées ci-dessous.
+
+**Le « Réutilisateur » est libre de réutiliser l’« Information » :**
+
+-   de la communiquer, la reproduire, la copier ;
+-   de l’adapter, la modifier, l’extraire et la transformer, notamment pour créer des « Informations dérivées » ;
+-   de la diffuser, la redistribuer, la publier et la transmettre, de l’exploiter à titre commercial, par exemple en la combinant avec d’autres informations, ou en l’incluant dans votre propre produit ou application.
+
+**Sous réserve de :**
+
+-   mentionner la paternité de l’«Information» : sa source (a minima le nom du  « Concédant ») et la date de la dernière mise à jour de l’« Information » réutilisée.
+
+Le « Réutilisateur » peut notamment s’ acquitter de cette condition en indiquant l’adresse (URL) renvoyant vers « l’Information » et assurant une mention effective de sa paternité.
+
+**Par exemple :**
+
+Dans le cas d’une réutilisation de la base SIRENE de l’INSEE, mentionner l’URL du « Concédant » : www.insee.fr + la date de dernière mise à jour de l’Information réutilisée.
+
+Cette mention de paternité ne doit ni conférer un caractère officiel à la « Réutilisation » de l’« Information », ni suggérer une quelconque reconnaissance ou caution par le « Concédant », ou par toute autre entité publique, du « Réutilisateur » ou de sa « Réutilisation ».
+
+## Données à caractère personnel
+
+L’« Information » mise à disposition peut contenir des « Données à caractère personnel » pouvant faire l’objet d’une « Réutilisation ». Alors, le « Concédant » informe le « Réutilisateur » (par tous moyens) de leur présence, l’ « Information » peut être librement réutilisée, sans faire obstacle aux libertés accordées par la présente licence, à condition de respecter le cadre légal relatif à la protection des données à caractère personnel.
+
+## Droits de propriété intellectuelle
+
+Il est garanti au « Réutilisateur » que l’ « Information » ne contient pas de « Droits de propriété intellectuelle »  appartenant à des tiers qui pourraient faire obstacle aux libertés qui lui sont accordées par la présente licence.
+
+Les éventuels « Droits de propriété intellectuelle » détenus par le « Concédant » sur l’ « Information » ne font pas obstacle aux libertés qui sont accordées par la présente licence. Lorsque le « Concédant » détient des « Droits de propriété intellectuelle » » sur l’ « Information », il les cède au « Réutilisateur » de façon non exclusive, à titre gracieux, pour le monde entier, pour toute la durée des « Droits de propriété intellectuelle », et le « Réutilisateur »  peut en faire tout usage conformément aux libertés et aux conditions définies par la présente licence.
+
+## Responsabilité
+
+L’ «Information» est mise à disposition telle que produite ou reçue, sans autre garantie expresse ou tacite qui n’est pas prévue par la présente licence. L’absence de défauts ou d’erreurs éventuellement contenues dans l’ «Information», comme la fourniture continue de l’ « Information » n’est pas garantie par le «Concédant». Il ne peut être tenu pour responsable de toute perte, préjudice ou dommage de quelque sorte causé à des tiers du fait de la « Réutilisation ».
+
+Le « Réutilisateur » est seul responsable de la « Réutilisation » de l’« Information ».
+
+La « Réutilisation » ne doit pas induire en erreur des tiers quant au contenu de l’« Information », sa source et sa date de mise à jour.
+
+## Droit applicable
+
+La présente licence est régie par le droit français.
+
+### Compatibilité de la présente licence
+
+Elle a été conçue pour être compatible avec toute licence libre qui exige _a minima_ la mention de paternité. Elle est notamment compatible avec la version antérieure de la présente licence ainsi qu’avec les licences « Open Government Licence » (OGL) du Royaume-Uni, « Creative Commons Attribution » (CC-BY) de Creative Commons et « Open Data Commons Attribution » (ODC-BY) de l’Open Knowledge Foundation.
+
+## Définitions
+
+Sont considérés, au sens de la présente licence comme :
+
+-   Le « **Concédant** » : toute personne concédant un droit de « Réutilisation » sur l’« Information » dans les libertés et les conditions prévues par la présente licence.
+-   L’« **Information** » :
+    -   toute information publique figurant dans des documents communiqués ou publiés par une administration mentionnée au premier alinéa de l’article L.300-2 du CRPA ;
+    -   toute information mise à disposition par toute personne selon les termes et conditions de la présente licence.
+-   La « **Réutilisation** » : l’utilisation de l’« Information » à d’autres fins que celles pour lesquelles elle a été produite ou reçue.
+-   Le « **Réutilisateur** » : toute personne qui réutilise les « Informations »  conformément aux conditions de la présente licence.
+-   Des « **Données à caractère personnel** » : toute information se rapportant à une personne physique identifiée ou identifiable, pouvant être identifiée directement ou indirectement. Leur « Réutilisation » est subordonnée au respect du cadre juridique en vigueur.
+-   Une « **Information dérivée** » : toute nouvelle donnée ou information créées directement à partir de l’« Information » ou à partir d’une combinaison  de l’ « Information » et d’autres données ou informations non  soumises à cette licence.
+-   Les « **Droits de propriété intellectuelle** » : tous droits identifiés comme tels par le Code de la propriété intellectuelle (droit d’auteur, droits voisins au droit d’auteur, droit sui generis des producteurs de bases de données).
+
+## À propos de cette licence
+
+La présente licence a vocation à être utilisée par les administrations pour la réutilisation de leurs informations publiques. Elle peut également être utilisée par toute personne souhaitant mettre à disposition de l’« Information » dans les conditions définies par la présente licence.
+
+La France est dotée d’un cadre juridique global visant à une diffusion spontanée par les administrations de leurs informations publiques afin d’en permettre la plus large réutilisation.
+
+Le droit de la « Réutilisation » de l’« Information » des administrations est régi par le code des relations entre le public et l’administration (CRPA) et, le cas échéant, le code du patrimoine (livre II relatif aux archives).
+
+Cette licence facilite la réutilisation libre et gratuite des informations publiques et figure parmi les licences qui peuvent être utilisées par l’administration en vertu du décret pris en application de l’article L.323-2 du CRPA.
+
+Etalab est la mission chargée, sous l’autorité du Premier ministre, d’ouvrir le plus grand nombre de données publiques des administrations de l’État et de ses établissements publics. Elle a réalisé la Licence Ouverte pour faciliter la réutilisation libre et gratuite de ces informations publiques, telles que définies par l’article L321-1 du CRPA.
+
+Cette licence est une version 2.0 de la Licence Ouverte.
+
+Etalab se réserve la faculté de proposer de nouvelles versions de la Licence Ouverte. Cependant, les « Réutilisateurs » pourront continuer à réutiliser les informations disponibles sous cette licence s’ils le souhaitent.


### PR DESCRIPTION
Aujourd'hui les licences sont disponibles :
- en format pdf non accessible ([Licence Ouverte](https://www.etalab.gouv.fr/wp-content/uploads/2014/05/Licence_Ouverte.pdf) et [Licence Ouverte 2.0](https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf))
- sur un repo github ([Licence Ouverte 2.0](https://github.com/etalab/licence-ouverte/blob/master/LO.md))

Lorsqu'une personne clique sur la licence d'un jeu de données sur data.gouv.fr, donc, elle est renvoyée soit vers un pdf non accessible, soit vers un site tiers.
Exposer les licences sur data.gouv.fr permettrait de résoudre le problème d'accessibilité et ne pas renvoyer les utilisateurs vers un site tiers.

⚠️ À vérifier avec le pôle juridique avant le merge

Fix https://github.com/etalab/data.gouv.fr/issues/941