### PR TITLE
Removing mentions to app on the machine learning inventory page

### DIFF
--- a/pages/donnees_apprentissage-automatique.html
+++ b/pages/donnees_apprentissage-automatique.html
@@ -13,16 +13,6 @@ content_type: html
                 <div class="fr-container">
                         <div>
                                 <h1>Catalogue des datasets de data.gouv.fr pour le Machine Learning</h1>
-
-                                <div class="fr-col-12">
-                                        <div class="fr-highlight fr-my-6w">
-                                                <p>Pour davantage de lisibilité, l’inventaire présenté ici est également
-                                                        <a href="https://datascience.etalab.studio/dgml/">disponible
-                                                                sous la forme d’une
-                                                                application</a>.
-                                                </p>
-                                        </div>
-                                </div>
                         </div>
 
                         <div class="fr-grid-row">
@@ -101,26 +91,15 @@ content_type: html
                                                         exploitables
                                                         par des
                                                         algorithmes d’apprentissage automatique regroupés par tâche</b>.
-                                                Chaque jeu est accompagné :</p>
-                                        <div class="markdown">
-                                                <ul>
-                                                        <li>d’un <b>profiling</b> qui vous permettra d’explorer le jeu
-                                                                de
-                                                                données et d’obtenir un résumé
-                                                                de ses statistiques descriptives ;</li>
-                                                        <li>des <b>résultats de l’entraînement et du test automatique
+                                                Chaque jeu est accompagné des <b>résultats de l’entraînement et du test automatique
                                                                         d’algorithmes classiques de
                                                                         Machine Learning</b> : métriques, matrices de
                                                                 confusion,
-                                                                graphiques, etc.</li>
-                                                </ul>
-                                        </div>
+                                                                graphiques, etc.</p>
                                         <p><i>N.b.: Cette page est en cours de construction et est ouverte à la
                                                 contribution plus
                                                 de jeux de
-                                                données sont à venir. Le profiling a été effectué avec <a
-                                                        href="https://pandas-profiling.ydata.ai/docs/master/index.html">Pandas
-                                                        Profiling</a> et les
+                                                données sont à venir. Les
                                                 modèles ont été
                                                 entrainés à l’aide de <a
                                                         href="https://supervised.mljar.com/">mljar-supervised</a>.</i></p>
@@ -135,8 +114,6 @@ content_type: html
                                                         CO2 et de polluants de l’air.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/6ff09b59-84ca-4346-a8d1-3587ed94da15">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/6ff09b59-84ca-4346-a8d1-3587ed94da15/README.html">Modèle</a>
                                                                 (target variable: CO2)</li>
                                                         <li><a href="https://www.data.gouv.fr/fr/reuses/predict-co2-emissions-of-different-cars/">Réutilisation
@@ -151,13 +128,11 @@ content_type: html
                                                         Airbnb à Bordeaux.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/123e1c18-37e0-4147-ad65-768320387800">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/123e1c18-37e0-4147-ad65-768320387800/README.html">Modèle</a>
                                                                 (target variable: PrixNuitee)</li>
                                                 </ul>
                                         </div>
-                                        <h3><a href="https://www.data.gouv.fr/fr/datasets/agribalyse-r-synthese-1/">AGRIBALYSE®
+                                        <h3><a href="https://www.data.gouv.fr/fr/datasets/agribalyse-3-1-1-synthese/">AGRIBALYSE®
                                                         -
                                                         Synthèse</a></h3>
                                         <p><i>AGRIBALYSE® est une base de données de référence des indicateurs d’impacts
@@ -169,8 +144,6 @@ content_type: html
                                                         qui leur sont associés.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/c763b24a-a0fe-4e77-9586-3d5453c631cd">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/c763b24a-a0fe-4e77-9586-3d5453c631cd/README.html">Modèle</a>
                                                                 (target variable: DQR — Note de qualité de la donnée (1
                                                                 excellente ; 5 très faible))
@@ -190,8 +163,6 @@ content_type: html
                                                         métropolitaine.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/aa50b408-49f4-4608-97fd-dd8fb21ef239">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/aa50b408-49f4-4608-97fd-dd8fb21ef239/README.html">Modèle</a>
                                                                         (target variable: Log_soc)</li>
                                                         <li><a href="https://www.data.gouv.fr/fr/reuses/deep-learning-pour-la-prediction-de-la-densite/">Réutilisation
@@ -210,8 +181,6 @@ content_type: html
                                                         trimestre de 2020.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/90a98de0-f562-4328-aa16-fe0dd1dca60f">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://github.com/etalab-ia/DGML/blob/main/docs/automodels/90a98de0-f562-4328-aa16-fe0dd1dca60f/README.md">Modèle</a>
                                                                         (target variable: valeur foncière)</li>
                                                 </ul>
@@ -230,8 +199,6 @@ content_type: html
                                         </p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/ce203343-6ed9-4fd3-b310-e553ae437f6d">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/AutoML_conc_poll_reg/README.html">Modèle</a>
                                                                 (target variable: valeur)</li>
                                                 </ul>
@@ -270,8 +237,6 @@ content_type: html
                                                         données.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/6af37c98-0933-4ae4-8380-5f63212fb52a">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/6af37c98-0933-4ae4-8380-5f63212fb52a/README.html">Modèle</a>
                                                                         (target variable: grav)</li>
                                                         <li><a href="https://www.data.gouv.fr/fr/reuses/machine-learning-pour-predire-la-gravite-des-accidents/">Réutilisation
@@ -287,8 +252,6 @@ content_type: html
                                                         Saint-Germain-en-Laye.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/96f4164d-956d-4c1c-b161-68724eb0ccdc">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/96f4164d-956d-4c1c-b161-68724eb0ccdc/README.html">Modèle</a>
                                                                 (target variable: classification_diagnostic)</li>
                                                 </ul>
@@ -306,8 +269,6 @@ content_type: html
                                                         agroalimentaires.</i></p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/fff0cc27-977b-40d5-9c11-f7e4e79a0b72">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/fff0cc27-977b-40d5-9c11-f7e4e79a0b72/README.html">Modèle</a>
                                                                 (target variable : Synthese_eval_sanit)</li>
                                                         <li><a href="https://www.data.gouv.fr/fr/reuses/predire-la-qualite-sanitaire-dun-etablissement-alimentaire/">Réutilisation
@@ -328,8 +289,6 @@ content_type: html
                                         </p>
                                         <div class="markdown">
                                                 <ul>
-                                                        <li><a href="https://datascience.etalab.studio/dgml/ce203343-6ed9-4fd3-b310-e553ae437f6d">Profiling</a>
-                                                        </li>
                                                         <li><a href="https://etalab-ia.github.io/DGML/automodels/AutoML_conc_poll_class/README.html">Modèle</a>
                                                                 (target variable: nom_poll)</li>
                                                 </ul>


### PR DESCRIPTION
The dgml app is not maintained or updated anymore.
All mentions to the app were deleted from the page.
A dataset link has been corrected.