### PR TITLE
Ajout section restauration collective

### DIFF
--- a/pages/donnees_agriculture-alimentation.html
+++ b/pages/donnees_agriculture-alimentation.html
@@ -122,6 +122,11 @@ content_type: html
                                                         </a>
                                                     </li>
                                                     <li class="fr-sidemenu__item">
+                                                        <a class="fr-sidemenu__link" href="#restauration-collective" target="_self">
+                                                            Restauration collective
+                                                        </a>
+                                                    </li>
+                                                    <li class="fr-sidemenu__item">
                                                         <a class="fr-sidemenu__link" href="#nutrition" target="_self">
                                                             Nutrition
                                                         </a>
@@ -365,6 +370,18 @@ content_type: html
                                     <li><a href="https://www.data.gouv.fr/fr/datasets/rappelconso/">RappelConso</a> :
                                         liste
                                         des fiches de rappels
+                                    </li>
+                                </ul>
+                            </div>
+                          
+                            <h3 id="securite-alimentaire">Restauration collective</h3>
+                            <div class="markdown">
+                                <ul>
+                                    <li>
+                                      <a href="https://www.data.gouv.fr/fr/datasets/registre-national-des-cantines/"> Registre national des cantines </a>
+                                    </li>
+                                    <li>
+                                      <a href="https://www.data.gouv.fr/fr/datasets/resultats-de-campagnes-de-teledeclaration-des-cantines/">Télédéclarations des cantines sur les achats alimentaires</a>
                                     </li>
                                 </ul>
                             </div>

--- a/pages/donnees_agriculture-alimentation.html
+++ b/pages/donnees_agriculture-alimentation.html
@@ -374,7 +374,7 @@ content_type: html
                                 </ul>
                             </div>
                           
-                            <h3 id="securite-alimentaire">Restauration collective</h3>
+                            <h3 id="restauration-collective">Restauration collective</h3>
                             <div class="markdown">
                                 <ul>
                                     <li>


### PR DESCRIPTION
Ajout d'une section restauration collective dans la page 'Agriculture et Alimentation' pour ajouter deux jeux de données produits par l'équipe ma-cantine pour le compte de la Direction Générale de l'Alimentation (MASA)